### PR TITLE
Organize Main Entry Point Script

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,9 +2,8 @@
 
 import yargs from "yargs";
 import { globSync } from "glob";
-import { execSync } from "node:child_process";
 import { hideBin } from "yargs/helpers";
-import { compileCppTest } from "./test/index.js";
+import { compileCppTest, runCppTest } from "./test/index.js";
 
 yargs(hideBin(process.argv))
   .scriptName("leetsolve")
@@ -20,7 +19,7 @@ yargs(hideBin(process.argv))
         const testExec = compileCppTest(testFile);
 
         process.stdout.write(`Running ${testExec}...\n`);
-        execSync(testExec, { stdio: "inherit" });
+        runCppTest(testExec);
       }
     },
   )

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,9 +3,8 @@
 import yargs from "yargs";
 import { globSync } from "glob";
 import { execSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import path from "node:path";
 import { hideBin } from "yargs/helpers";
+import { compileCppTest } from "./test/index.js";
 
 yargs(hideBin(process.argv))
   .scriptName("leetsolve")
@@ -18,14 +17,7 @@ yargs(hideBin(process.argv))
       const testFiles = globSync("**/test.cpp");
       for (const testFile of testFiles) {
         process.stdout.write(`Compiling ${testFile}...\n`);
-
-        const buildDir = path.join("build", path.dirname(testFile));
-        mkdirSync(buildDir, { recursive: true });
-
-        const testExec = path.join(buildDir, "test");
-        execSync(`clang++ --std=c++20 ${testFile} -o ${testExec}`, {
-          stdio: "inherit",
-        });
+        const testExec = compileCppTest(testFile);
 
         process.stdout.write(`Running ${testExec}...\n`);
         execSync(testExec, { stdio: "inherit" });

--- a/src/test/cpp.ts
+++ b/src/test/cpp.ts
@@ -1,0 +1,21 @@
+import { execSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Compile a C++ test file using Clang.
+ *
+ * @param testFile - The path of the C++ test file to compile.
+ * @returns A path to the compiled test executable.
+ */
+export function compileCppTest(testFile: string): string {
+  const buildDir = path.join("build", path.dirname(testFile));
+  mkdirSync(buildDir, { recursive: true });
+
+  const testExec = path.join(buildDir, "test");
+  execSync(`clang++ --std=c++20 ${testFile} -o ${testExec}`, {
+    stdio: "inherit",
+  });
+
+  return testExec;
+}

--- a/src/test/cpp.ts
+++ b/src/test/cpp.ts
@@ -19,3 +19,12 @@ export function compileCppTest(testFile: string): string {
 
   return testExec;
 }
+
+/**
+ * Run a C++ test executable.
+ *
+ * @param testExec - The path of the C++ test executable to run.
+ */
+export function runCppTest(testExec: string) {
+  execSync(testExec, { stdio: "inherit" });
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,1 +1,1 @@
-export { compileCppTest } from "./cpp.js";
+export { compileCppTest, runCppTest } from "./cpp.js";

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,1 @@
+export { compileCppTest } from "./cpp.js";


### PR DESCRIPTION
This pull request resolves #10 by introducing the `compileCppTest` and `runCppTest` functions in the `src/test/cpp.ts` file that were created based on lines in the `src/bin.ts` file.