### PR TITLE
Add Unit Testing to C++ Test Functions

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -12,6 +12,7 @@
     "^(\\.{1,2}/.*)\\.js$": "$1"
   },
   "preset": "ts-jest/presets/default-esm",
+  "setupFilesAfterEnv": ["jest-extended/all"],
   "transform": {
     "^.+\\.ts$": ["ts-jest", { "useESM": true }]
   },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.20",
     "@types/yargs": "^17.0.32",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
     "start": "tsx src/bin.ts",
-    "test": "jest"
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn jest"
   },
   "dependencies": {
     "glob": "^10.3.10",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-tsdoc": "^0.2.17",
     "jest": "^29.7.0",
+    "jest-extended": "^4.0.2",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "tsx": "^4.7.1",

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -9,6 +9,14 @@ jest.unstable_mockModule("node:fs", () => ({
   mkdirSync: jest.fn(),
 }));
 
+beforeEach(async () => {
+  const { execSync } = await import("node:child_process");
+  const { mkdirSync } = await import("node:fs");
+
+  jest.mocked(execSync).mockClear();
+  jest.mocked(mkdirSync).mockClear();
+});
+
 it("should compile a C++ test file", async () => {
   const { execSync } = await import("node:child_process");
   const { mkdirSync } = await import("node:fs");
@@ -28,4 +36,15 @@ it("should compile a C++ test file", async () => {
   expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
 
   expect(testExec).toBe("build/path/to/test");
+});
+
+it("should run a C++ test executable", async () => {
+  const { execSync } = await import("node:child_process");
+  const { runCppTest } = await import("./cpp.js");
+
+  runCppTest("build/path/to/test");
+
+  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
+    stdio: "inherit",
+  });
 });

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -1,0 +1,31 @@
+import { jest } from "@jest/globals";
+import "jest-extended";
+
+jest.unstable_mockModule("node:child_process", () => ({
+  execSync: jest.fn(),
+}));
+
+jest.unstable_mockModule("node:fs", () => ({
+  mkdirSync: jest.fn(),
+}));
+
+it("should compile a C++ test file", async () => {
+  const { execSync } = await import("node:child_process");
+  const { mkdirSync } = await import("node:fs");
+  const { compileCppTest } = await import("./cpp.js");
+
+  const testExec = compileCppTest("path/to/test.cpp");
+
+  expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
+    recursive: true,
+  });
+  expect(execSync).toHaveBeenCalledExactlyOnceWith(
+    "clang++ --std=c++20 path/to/test.cpp -o build/path/to/test",
+    {
+      stdio: "inherit",
+    },
+  );
+  expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
+
+  expect(testExec).toBe("build/path/to/test");
+});

--- a/src/test/cpp.ts
+++ b/src/test/cpp.ts
@@ -25,6 +25,6 @@ export function compileCppTest(testFile: string): string {
  *
  * @param testExec - The path of the C++ test executable to run.
  */
-export function runCppTest(testExec: string) {
+export function runCppTest(testExec: string): void {
   execSync(testExec, { stdio: "inherit" });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,6 +3394,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "leetsolve@workspace:."
   dependencies:
+    "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.11.20"
     "@types/yargs": "npm:^17.0.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,7 +2933,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.7.0":
+"jest-diff@npm:^29.0.0, jest-diff@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-diff@npm:29.7.0"
   dependencies:
@@ -2981,7 +2981,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^29.6.3":
+"jest-extended@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "jest-extended@npm:4.0.2"
+  dependencies:
+    jest-diff: "npm:^29.0.0"
+    jest-get-type: "npm:^29.0.0"
+  peerDependencies:
+    jest: ">=27.2.5"
+  peerDependenciesMeta:
+    jest:
+      optional: true
+  checksum: 10c0/305fdb6885ab71755830b70690b8db6ea6fd9adca92360ea1a37c0d2fa6567a68b57178dd7707d112fc57b01ab75b66f28a1c550ed0e6b1b8628600a812c2277
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.0.0, jest-get-type@npm:^29.6.3":
   version: 29.6.3
   resolution: "jest-get-type@npm:29.6.3"
   checksum: 10c0/552e7a97a983d3c2d4e412a44eb7de0430ff773dd99f7500962c268d6dfbfa431d7d08f919c9d960530e5f7f78eb47f267ad9b318265e5092b3ff9ede0db7c2b
@@ -3388,6 +3403,7 @@ __metadata:
     eslint-plugin-tsdoc: "npm:^0.2.17"
     glob: "npm:^10.3.10"
     jest: "npm:^29.7.0"
+    jest-extended: "npm:^4.0.2"
     prettier: "npm:^3.2.5"
     ts-jest: "npm:^29.1.2"
     tsx: "npm:^4.7.1"


### PR DESCRIPTION
This pull request resolves #12 by introducing the following changes:
- Integrating [Jest Extended](https://jest-extended.jestcommunity.dev/) into this project's testing.
- Modifying the `test` script to set `NODE_OPTIONS` to `--experimental-vm-modules` before running tests because it is required for ESM module mocking.
- Adding testing for the `compileCppTest` and `runCppTest` functions.