### PR TITLE
Rename Project to LeetTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # LeetTest
 
-[![version](https://img.shields.io/github/v/release/threeal/leetsolve?style=flat-square)](https://github.com/threeal/leetsolve/releases)
-[![license](https://img.shields.io/github/license/threeal/leetsolve?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/leetsolve/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/leetsolve/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/leetsolve/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/leetsolve/actions/workflows/test.yaml)
+[![version](https://img.shields.io/github/v/release/threeal/leettest?style=flat-square)](https://github.com/threeal/leettest/releases)
+[![license](https://img.shields.io/github/license/threeal/leettest?style=flat-square)](./LICENSE)
+[![build status](https://img.shields.io/github/actions/workflow/status/threeal/leettest/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/leettest/actions/workflows/build.yaml)
+[![test status](https://img.shields.io/github/actions/workflow/status/threeal/leettest/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/leettest/actions/workflows/test.yaml)
 
 LeetTest is a tool for compiling and testing solutions to [LeetCode](https://leetcode.com/) problems.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# LeetSolve
+# LeetTest
 
 [![version](https://img.shields.io/github/v/release/threeal/leetsolve?style=flat-square)](https://github.com/threeal/leetsolve/releases)
 [![license](https://img.shields.io/github/license/threeal/leetsolve?style=flat-square)](./LICENSE)
 [![build status](https://img.shields.io/github/actions/workflow/status/threeal/leetsolve/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/leetsolve/actions/workflows/build.yaml)
 [![test status](https://img.shields.io/github/actions/workflow/status/threeal/leetsolve/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/leetsolve/actions/workflows/test.yaml)
 
-LeetSolve is a tool for building and testing solutions to [LeetCode](https://leetcode.com/) problems.
+LeetTest is a tool for compiling and testing solutions to [LeetCode](https://leetcode.com/) problems.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "leetsolve",
+  "name": "leettest",
   "version": "0.1.0",
-  "description": "Tool for building and testing solutions to LeetCode problems",
+  "description": "Tool for compiling and testing solutions to LeetCode problems",
   "keywords": [
     "LeetCode",
     "tool",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
     "build",
     "test"
   ],
-  "homepage": "https://github.com/threeal/leetspace#readme",
+  "homepage": "https://github.com/threeal/leettest#readme",
   "bugs": {
-    "url": "https://github.com/threeal/leetspace/issues",
+    "url": "https://github.com/threeal/leettest/issues",
     "email": "alfi.maulana.f@gmail.com"
   },
-  "repository": "github:threeal/leetspace",
+  "repository": "github:threeal/leettest",
   "license": "MIT",
   "author": "Alfi Maulana <alfi.maulana.f@gmail.com>",
   "type": "module",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -6,7 +6,7 @@ import { hideBin } from "yargs/helpers";
 import { compileCppTest, runCppTest } from "./test/index.js";
 
 yargs(hideBin(process.argv))
-  .scriptName("leetsolve")
+  .scriptName("leettest")
   .version("0.1.0")
   .command(
     "$0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3390,9 +3390,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"leetsolve@workspace:.":
+"leettest@workspace:.":
   version: 0.0.0-use.local
-  resolution: "leetsolve@workspace:."
+  resolution: "leettest@workspace:."
   dependencies:
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
@@ -3411,7 +3411,7 @@ __metadata:
     typescript: "npm:^5.3.3"
     yargs: "npm:^17.7.2"
   bin:
-    leetsolve: dist/bin.js
+    leettest: dist/bin.js
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This pull request resolves #16 by renaming this project to LeetTest. It also updates the GitHub URL of this project to `threeal/leettest`.