### PR TITLE
Separate `test/cpp.ts` into Multiple Files

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,7 +3,7 @@
 import yargs from "yargs";
 import { globSync } from "glob";
 import { hideBin } from "yargs/helpers";
-import { compileCppTest, runCppTest } from "./test/index.js";
+import { compileCppTest, runCppTest } from "./test/cpp.js";
 
 yargs(hideBin(process.argv))
   .scriptName("leettest")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { compileCppTest, runCppTest } from "./test/index.js";
+export { compileCppTest, runCppTest } from "./test/cpp.js";

--- a/src/test/cpp.ts
+++ b/src/test/cpp.ts
@@ -1,0 +1,2 @@
+export { compileCppTest } from "./cpp/compile.js";
+export { runCppTest } from "./cpp/run.js";

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -20,7 +20,7 @@ beforeEach(async () => {
 it("should compile a C++ test file", async () => {
   const { execSync } = await import("node:child_process");
   const { mkdirSync } = await import("node:fs");
-  const { compileCppTest } = await import("./cpp.js");
+  const { compileCppTest } = await import("./compile.js");
 
   const testExec = compileCppTest("path/to/test.cpp");
 
@@ -36,15 +36,4 @@ it("should compile a C++ test file", async () => {
   expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
 
   expect(testExec).toBe("build/path/to/test");
-});
-
-it("should run a C++ test executable", async () => {
-  const { execSync } = await import("node:child_process");
-  const { runCppTest } = await import("./cpp.js");
-
-  runCppTest("build/path/to/test");
-
-  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
-    stdio: "inherit",
-  });
 });

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 /**
- * Compile a C++ test file using Clang.
+ * Compiles a C++ test file using Clang.
  *
  * @param testFile - The path of the C++ test file to compile.
  * @returns A path to the compiled test executable.
@@ -18,13 +18,4 @@ export function compileCppTest(testFile: string): string {
   });
 
   return testExec;
-}
-
-/**
- * Run a C++ test executable.
- *
- * @param testExec - The path of the C++ test executable to run.
- */
-export function runCppTest(testExec: string): void {
-  execSync(testExec, { stdio: "inherit" });
 }

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -1,2 +1,0 @@
-export { compileCppTest } from "./compile.js";
-export { runCppTest } from "./run.js";

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -1,0 +1,2 @@
+export { compileCppTest } from "./compile.js";
+export { runCppTest } from "./run.js";

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -1,0 +1,17 @@
+import { jest } from "@jest/globals";
+import "jest-extended";
+
+jest.unstable_mockModule("node:child_process", () => ({
+  execSync: jest.fn(),
+}));
+
+it("should run a C++ test executable", async () => {
+  const { execSync } = await import("node:child_process");
+  const { runCppTest } = await import("./run.js");
+
+  runCppTest("build/path/to/test");
+
+  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
+    stdio: "inherit",
+  });
+});

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -1,0 +1,10 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Runs a C++ test executable.
+ *
+ * @param testExec - The path of the C++ test executable to run.
+ */
+export function runCppTest(testExec: string): void {
+  execSync(testExec, { stdio: "inherit" });
+}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,1 +1,1 @@
-export { compileCppTest, runCppTest } from "./cpp.js";
+export { compileCppTest, runCppTest } from "./cpp/index.js";

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,1 +1,0 @@
-export { compileCppTest, runCppTest } from "./cpp/index.js";


### PR DESCRIPTION
This pull request resolves #20 by separating the `test/cpp.ts` file into `test/cpp/compile.ts` and `test/cpp/run.ts` files. It also modifies the `test/index.ts` file to `test/cpp.ts`.