### PR TITLE
Modify Compile Function to Specify Output Path

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,6 +2,7 @@
 
 import yargs from "yargs";
 import { globSync } from "glob";
+import path from "node:path";
 import { hideBin } from "yargs/helpers";
 import { compileCppTest, runCppTest } from "./test/cpp.js";
 
@@ -16,7 +17,8 @@ yargs(hideBin(process.argv))
       const testFiles = globSync("**/test.cpp");
       for (const testFile of testFiles) {
         process.stdout.write(`Compiling ${testFile}...\n`);
-        const testExec = compileCppTest(testFile);
+        const testExec = path.join("build", path.dirname(testFile), "test");
+        compileCppTest(testFile, testExec);
 
         process.stdout.write(`Running ${testExec}...\n`);
         runCppTest(testExec);

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -22,7 +22,7 @@ it("should compile a C++ test file", async () => {
   const { mkdirSync } = await import("node:fs");
   const { compileCppTest } = await import("./compile.js");
 
-  const testExec = compileCppTest("path/to/test.cpp");
+  compileCppTest("path/to/test.cpp", "build/path/to/test");
 
   expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
     recursive: true,
@@ -34,6 +34,4 @@ it("should compile a C++ test file", async () => {
     },
   );
   expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
-
-  expect(testExec).toBe("build/path/to/test");
 });

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -6,16 +6,12 @@ import path from "node:path";
  * Compiles a C++ test file using Clang.
  *
  * @param testFile - The path of the C++ test file to compile.
- * @returns A path to the compiled test executable.
+ * @param outFile - The path of the compiled executable output.
  */
-export function compileCppTest(testFile: string): string {
-  const buildDir = path.join("build", path.dirname(testFile));
-  mkdirSync(buildDir, { recursive: true });
+export function compileCppTest(testFile: string, outFile: string): void {
+  mkdirSync(path.dirname(outFile), { recursive: true });
 
-  const testExec = path.join(buildDir, "test");
-  execSync(`clang++ --std=c++20 ${testFile} -o ${testExec}`, {
+  execSync(`clang++ --std=c++20 ${testFile} -o ${outFile}`, {
     stdio: "inherit",
   });
-
-  return testExec;
 }


### PR DESCRIPTION
This pull request resolves #27 by modifying the `compileCppTest` function by adding a new `outFile` parameter for specifying the output file.