### PR TITLE
Glob Solution Files Instead of Test Files

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -14,8 +14,11 @@ yargs(hideBin(process.argv))
     "Compile and test solutions to LeetCode's problems",
     (yargs) => yargs,
     () => {
-      const testFiles = globSync("**/test.cpp");
-      for (const testFile of testFiles) {
+      const solutionFiles = globSync("**/solution.cpp");
+      for (const solutionFile of solutionFiles) {
+        process.stdout.write(`Testing ${solutionFile}...\n`);
+        const testFile = path.join(path.dirname(solutionFile), "test.cpp");
+
         process.stdout.write(`Compiling ${testFile}...\n`);
         const testExec = path.join("build", path.dirname(testFile), "test");
         compileCppTest(testFile, testExec);


### PR DESCRIPTION
This pull request resolves #29 by modifying the main command to glob the `solution.cpp` files instead of the `test.cpp` files.