### PR TITLE
Add Function for Testing C++ Solution

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,29 +2,20 @@
 
 import yargs from "yargs";
 import { globSync } from "glob";
-import path from "node:path";
 import { hideBin } from "yargs/helpers";
-import { compileCppTest, runCppTest } from "./test/cpp.js";
+import { testCppSolution } from "./test/cpp.js";
 
 yargs(hideBin(process.argv))
   .scriptName("leettest")
   .version("0.1.0")
   .command(
     "$0",
-    "Compile and test solutions to LeetCode's problems",
+    "Compile and test solutions to LeetCode problems",
     (yargs) => yargs,
     () => {
       const solutionFiles = globSync("**/solution.cpp");
       for (const solutionFile of solutionFiles) {
-        process.stdout.write(`Testing ${solutionFile}...\n`);
-        const testFile = path.join(path.dirname(solutionFile), "test.cpp");
-
-        process.stdout.write(`Compiling ${testFile}...\n`);
-        const testExec = path.join("build", path.dirname(testFile), "test");
-        compileCppTest(testFile, testExec);
-
-        process.stdout.write(`Running ${testExec}...\n`);
-        runCppTest(testExec);
+        testCppSolution(solutionFile);
       }
     },
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { compileCppTest, runCppTest } from "./test/cpp.js";
+export { testCppSolution } from "./test/cpp.js";

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -1,0 +1,25 @@
+import { jest } from "@jest/globals";
+import "jest-extended";
+
+jest.unstable_mockModule("./cpp/compile.js", () => ({
+  compileCppTest: jest.fn(),
+}));
+
+jest.unstable_mockModule("./cpp/run.js", () => ({
+  runCppTest: jest.fn(),
+}));
+
+it("should test a C++ solution", async () => {
+  const { compileCppTest } = await import("./cpp/compile.js");
+  const { runCppTest } = await import("./cpp/run.js");
+  const { testCppSolution } = await import("./cpp.js");
+
+  testCppSolution("path/to/solution.cpp");
+
+  expect(compileCppTest).toHaveBeenCalledExactlyOnceWith(
+    "path/to/test.cpp",
+    "build/path/to/test",
+  );
+  expect(runCppTest).toHaveBeenCalledAfter(jest.mocked(compileCppTest));
+  expect(runCppTest).toHaveBeenCalledExactlyOnceWith("build/path/to/test");
+});

--- a/src/test/cpp.ts
+++ b/src/test/cpp.ts
@@ -1,2 +1,23 @@
-export { compileCppTest } from "./cpp/compile.js";
-export { runCppTest } from "./cpp/run.js";
+import path from "node:path";
+import { compileCppTest } from "./cpp/compile.js";
+import { runCppTest } from "./cpp/run.js";
+
+/**
+ * Tests the C++ solution of a LeetCode problem.
+ *
+ * This function will compile the C++ solution files into a test executable
+ * and run the executable for testing the solution.
+ *
+ * @param solutionFile - The path of the C++ solution file to test.
+ */
+export function testCppSolution(solutionFile: string): void {
+  process.stdout.write(`Testing ${solutionFile}...\n`);
+  const testFile = path.join(path.dirname(solutionFile), "test.cpp");
+
+  process.stdout.write(`Compiling ${testFile}...\n`);
+  const testExec = path.join("build", path.dirname(testFile), "test");
+  compileCppTest(testFile, testExec);
+
+  process.stdout.write(`Running ${testExec}...\n`);
+  runCppTest(testExec);
+}


### PR DESCRIPTION
This pull request resolves #31 by adding a `testCppSolution` function extracted from the lines in the main command. Additionally, it adds unit tests for that function.