### PR TITLE
Add Function for Reading YAML Schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "glob": "^10.3.10",
+    "yaml": "^2.4.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/sample/problems/2235/test.yaml
+++ b/sample/problems/2235/test.yaml
@@ -1,0 +1,18 @@
+cpp:
+  function:
+    name: sum
+    inputs: [int, int]
+    output: int
+
+examples:
+  1:
+    inputs:
+      num1: 12
+      num2: 5
+    output: 17
+
+  2:
+    inputs:
+      num1: -10
+      num2: 4
+    output: -6

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { testCppSolution } from "./test/cpp.js";
-export { readYamlSchema } from "./test/schema.js";
+export { readYamlSchema, Schema } from "./test/schema.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { testCppSolution } from "./test/cpp.js";
+export { readYamlSchema } from "./test/schema.js";

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1,0 +1,64 @@
+import { jest } from "@jest/globals";
+import "jest-extended";
+
+jest.unstable_mockModule("node:fs", () => ({
+  readFileSync: jest.fn(),
+}));
+
+it("should read a YAML schema file", async () => {
+  const { readFileSync } = await import("node:fs");
+  const { readYamlSchema } = await import("./schema.js");
+
+  jest.mocked(readFileSync).mockReturnValue(`
+cpp:
+  function:
+    name: sum
+    inputs: [int, int]
+    output: int
+
+examples:
+  1:
+    inputs:
+      num1: 12
+      num2: 5
+    output: 17
+
+  2:
+    inputs:
+      num1: -10
+      num2: 4
+    output: -6
+  `);
+
+  const schema = readYamlSchema("path/to/test.yaml");
+
+  expect(readFileSync).toHaveBeenCalledExactlyOnceWith(
+    "path/to/test.yaml",
+    "utf-8",
+  );
+  expect(schema).toStrictEqual({
+    cpp: {
+      function: {
+        name: "sum",
+        inputs: ["int", "int"],
+        output: "int",
+      },
+    },
+    examples: {
+      1: {
+        inputs: {
+          num1: 12,
+          num2: 5,
+        },
+        output: 17,
+      },
+      2: {
+        inputs: {
+          num1: -10,
+          num2: 4,
+        },
+        output: -6,
+      },
+    },
+  });
+});

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import YAML from "yaml";
+
+/**
+ * Reads a test schema from a YAML file.
+ *
+ * @param schemaFile - The path of the YAML schema file.
+ * @returns The parsed test schema.
+ */
+export function readYamlSchema(schemaFile: string) {
+  const data = readFileSync(schemaFile, "utf-8");
+  return YAML.parse(data);
+}

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -1,13 +1,29 @@
 import { readFileSync } from "node:fs";
 import YAML from "yaml";
 
+export interface Schema {
+  cpp: {
+    function: {
+      name: string;
+      inputs: string[];
+      output: string[];
+    };
+  };
+  examples: {
+    [key: string]: {
+      inputs: { [key: string]: unknown };
+      output: unknown;
+    };
+  };
+}
+
 /**
  * Reads a test schema from a YAML file.
  *
  * @param schemaFile - The path of the YAML schema file.
  * @returns The parsed test schema.
  */
-export function readYamlSchema(schemaFile: string) {
+export function readYamlSchema(schemaFile: string): Schema {
   const data = readFileSync(schemaFile, "utf-8");
   return YAML.parse(data);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3409,6 +3409,7 @@ __metadata:
     ts-jest: "npm:^29.1.2"
     tsx: "npm:^4.7.1"
     typescript: "npm:^5.3.3"
+    yaml: "npm:^2.4.0"
     yargs: "npm:^17.7.2"
   bin:
     leettest: dist/bin.js
@@ -4713,6 +4714,15 @@ __metadata:
   version: 4.0.0
   resolution: "yallist@npm:4.0.0"
   checksum: 10c0/2286b5e8dbfe22204ab66e2ef5cc9bbb1e55dfc873bbe0d568aa943eb255d131890dfd5bf243637273d31119b870f49c18fcde2c6ffbb7a7a092b870dc90625a
+  languageName: node
+  linkType: hard
+
+"yaml@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "yaml@npm:2.4.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/97ab0b5a0714c92e4dd75120a6a63e470b0adc282afae0a701bf38f8c42cbf6429fcd6aca883e3a63c68936ab841862e6c69e2d66d355c3e4fc7cfd346af2108
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request resolves #23 by introducing the following changes:
- Adding a sample YAML schema for problem 2235.
- Adding a `readYamlSchema` function along with its testing for reading a test schema from a YAML file.
- Adding a `Schema` interface.