### PR TITLE
Fix Module Resolution During Testing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
This pull request fixes #36 by setting the `moduleResolution` in the `tsconfig.json` file to `node16`.