### PR TITLE
Remove Badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # LeetTest
 
-[![version](https://img.shields.io/github/v/release/threeal/leettest?style=flat-square)](https://github.com/threeal/leettest/releases)
-[![license](https://img.shields.io/github/license/threeal/leettest?style=flat-square)](./LICENSE)
-[![build status](https://img.shields.io/github/actions/workflow/status/threeal/leettest/build.yaml?branch=main&style=flat-square)](https://github.com/threeal/leettest/actions/workflows/build.yaml)
-[![test status](https://img.shields.io/github/actions/workflow/status/threeal/leettest/test.yaml?branch=main&label=test&style=flat-square)](https://github.com/threeal/leettest/actions/workflows/test.yaml)
-
 LeetTest is a tool for compiling and testing solutions to [LeetCode](https://leetcode.com/) problems.
 
 ## License


### PR DESCRIPTION
This pull request resolves #63 by simply removing badges from the `README.md` file.