### PR TITLE
Fix Tasks Failure Displaying Help Message

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -24,7 +24,12 @@ yargs(hideBin(process.argv))
           }),
         ),
       );
-      await task.run();
+
+      try {
+        await task.run();
+      } catch (err) {
+        console.error(err);
+      }
     },
   )
   .parse();


### PR DESCRIPTION
This pull request resolves #67 by catching an exception when calling `task.run()` inside the yargs command.