### PR TITLE
Execute All Commands Silently

### DIFF
--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -29,6 +29,7 @@ it("should compile a C++ test file", async () => {
   });
   expect(execSync).toHaveBeenCalledExactlyOnceWith(
     "clang++ --std=c++20 path/to/test.cpp -o build/path/to/test",
+    { stdio: "pipe" },
   );
   expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
 });

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -11,5 +11,5 @@ import path from "node:path";
 export function compileCppTest(testFile: string, outFile: string): void {
   mkdirSync(path.dirname(outFile), { recursive: true });
 
-  execSync(`clang++ --std=c++20 ${testFile} -o ${outFile}`);
+  execSync(`clang++ --std=c++20 ${testFile} -o ${outFile}`, { stdio: "pipe" });
 }

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -11,5 +11,7 @@ it("should run a C++ test executable", async () => {
 
   runCppTest("build/path/to/test");
 
-  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test");
+  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
+    stdio: "pipe",
+  });
 });

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -6,5 +6,5 @@ import { execSync } from "node:child_process";
  * @param testExec - The path of the C++ test executable to run.
  */
 export function runCppTest(testExec: string): void {
-  execSync(testExec);
+  execSync(testExec, { stdio: "pipe" });
 }


### PR DESCRIPTION
This pull request resolves #80 by modifying both the `compileCppTest` and `runCppTest` functions to execute commands silently.