### PR TITLE
Enhance Task Error Formatting

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -25,7 +25,10 @@ yargs(hideBin(process.argv))
               }),
           }),
         ),
-        { exitOnError: false },
+        {
+          exitOnError: false,
+          rendererOptions: { collapseErrors: false },
+        },
       );
 
       try {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -27,7 +27,10 @@ yargs(hideBin(process.argv))
         ),
         {
           exitOnError: false,
-          rendererOptions: { collapseErrors: false },
+          rendererOptions: {
+            collapseErrors: false,
+            removeEmptyLines: false,
+          },
         },
       );
 


### PR DESCRIPTION
This pull request resolves #82 by setting the main task not to collapse errors and removing empty lines from the error outputs.