### PR TITLE
Add Count of Failed Test Cases Information

### DIFF
--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -102,6 +102,7 @@ it("should generate a C++ test file", async () => {
       `       ++failures;`,
       `     }`,
       `  }`,
+      `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
       `  return failures;`,
       `}`,
       ``,

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -94,6 +94,7 @@ export function generateCppTest(
     `       ++failures;`,
     `     }`,
     `  }`,
+    `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
     `  return failures;`,
     `}`,
     ``,


### PR DESCRIPTION
This pull request resolves #84 by outputting a line that displays information about the count of failed test cases after executing a solution test.