### PR TITLE
Utilize `.env.yarn` to Set `NODE_OPTIONS`

### DIFF
--- a/.env.yarn
+++ b/.env.yarn
@@ -1,0 +1,1 @@
+NODE_OPTIONS=--experimental-vm-modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.env.yarn
 !.eslint*
 !.git*
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint": "eslint --ignore-path .gitignore .",
     "prepack": "tsc",
     "start": "tsx src/bin.ts",
-    "test": "NODE_OPTIONS=--experimental-vm-modules yarn jest"
+    "test": "jest"
   },
   "dependencies": {
     "glob": "^10.3.12",


### PR DESCRIPTION
This pull request resolves #93 by utilizing the `.env.yarn` file to set the `NODE_OPTIONS` environment variable.