### PR TITLE
Add Test Cases Property in Test Schema

### DIFF
--- a/sample/problems/1688/test.yaml
+++ b/sample/problems/1688/test.yaml
@@ -8,11 +8,13 @@ cpp:
 
 examples:
   1:
+    name: example 1
     inputs:
       n: 7
     output: 6
 
   2:
+    name: example 2
     inputs:
       n: 14
     output: 13

--- a/sample/problems/1688/test.yaml
+++ b/sample/problems/1688/test.yaml
@@ -6,7 +6,7 @@ cpp:
         type: int
     output: int
 
-examples:
+cases:
   - name: example 1
     inputs:
       n: 7

--- a/sample/problems/1688/test.yaml
+++ b/sample/problems/1688/test.yaml
@@ -7,14 +7,12 @@ cpp:
     output: int
 
 examples:
-  1:
-    name: example 1
+  - name: example 1
     inputs:
       n: 7
     output: 6
 
-  2:
-    name: example 2
+  - name: example 2
     inputs:
       n: 14
     output: 13

--- a/sample/problems/2235/test.yaml
+++ b/sample/problems/2235/test.yaml
@@ -8,7 +8,7 @@ cpp:
         type: int
     output: int
 
-examples:
+cases:
   - name: example 1
     inputs:
       num1: 12

--- a/sample/problems/2235/test.yaml
+++ b/sample/problems/2235/test.yaml
@@ -10,12 +10,14 @@ cpp:
 
 examples:
   1:
+    name: example 1
     inputs:
       num1: 12
       num2: 5
     output: 17
 
   2:
+    name: example 2
     inputs:
       num1: -10
       num2: 4

--- a/sample/problems/2235/test.yaml
+++ b/sample/problems/2235/test.yaml
@@ -9,15 +9,13 @@ cpp:
     output: int
 
 examples:
-  1:
-    name: example 1
+  - name: example 1
     inputs:
       num1: 12
       num2: 5
     output: 17
 
-  2:
-    name: example 2
+  - name: example 2
     inputs:
       num1: -10
       num2: 4

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -37,8 +37,8 @@ it("should create a task for testing a C++ solution", async () => {
         output: "int",
       },
     },
-    examples: {
-      1: {
+    examples: [
+      {
         name: "example 1",
         inputs: {
           num1: 12,
@@ -46,7 +46,7 @@ it("should create a task for testing a C++ solution", async () => {
         },
         output: 17,
       },
-      2: {
+      {
         name: "example 2",
         inputs: {
           num1: -10,
@@ -54,7 +54,7 @@ it("should create a task for testing a C++ solution", async () => {
         },
         output: -6,
       },
-    },
+    ],
   };
 
   jest.mocked(readYamlSchema).mockReturnValue(schema);

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -39,6 +39,7 @@ it("should create a task for testing a C++ solution", async () => {
     },
     examples: {
       1: {
+        name: "example 1",
         inputs: {
           num1: 12,
           num2: 5,
@@ -46,6 +47,7 @@ it("should create a task for testing a C++ solution", async () => {
         output: 17,
       },
       2: {
+        name: "example 2",
         inputs: {
           num1: -10,
           num2: 4,

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -37,7 +37,7 @@ it("should create a task for testing a C++ solution", async () => {
         output: "int",
       },
     },
-    examples: [
+    cases: [
       {
         name: "example 1",
         inputs: {

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -22,7 +22,7 @@ it("should generate a C++ test file", async () => {
         output: "int",
       },
     },
-    examples: [
+    cases: [
       {
         name: "example 1",
         inputs: {

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -22,8 +22,8 @@ it("should generate a C++ test file", async () => {
         output: "int",
       },
     },
-    examples: {
-      1: {
+    examples: [
+      {
         name: "example 1",
         inputs: {
           num1: 12,
@@ -31,7 +31,7 @@ it("should generate a C++ test file", async () => {
         },
         output: 17,
       },
-      2: {
+      {
         name: "example 2",
         inputs: {
           num1: -10,
@@ -39,7 +39,7 @@ it("should generate a C++ test file", async () => {
         },
         output: -6,
       },
-    },
+    ],
   };
 
   generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp");

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -24,6 +24,7 @@ it("should generate a C++ test file", async () => {
     },
     examples: {
       1: {
+        name: "example 1",
         inputs: {
           num1: 12,
           num2: 5,
@@ -31,6 +32,7 @@ it("should generate a C++ test file", async () => {
         output: 17,
       },
       2: {
+        name: "example 2",
         inputs: {
           num1: -10,
           num2: 4,

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -37,19 +37,19 @@ export function generateCppTest(
 
   const testCases: string[] = [];
 
-  for (const example of schema.examples) {
+  for (const c of schema.cases) {
     const inputs: string[] = [];
     for (const input of schema.cpp.function.inputs) {
-      inputs.push(`      .${input.name}{${example.inputs[input.name]}}`);
+      inputs.push(`      .${input.name}{${c.inputs[input.name]}}`);
     }
 
     const lines = [
       `  {`,
-      `    .name{"${example.name}"},`,
+      `    .name{"${c.name}"},`,
       `    .inputs{`,
       inputs.join(",\n"),
       `    },`,
-      `    .output{${example.output}}`,
+      `    .output{${c.output}}`,
       `  }`,
     ];
 

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -37,7 +37,7 @@ export function generateCppTest(
 
   const testCases: string[] = [];
 
-  for (const example of Object.values(schema.examples)) {
+  for (const example of schema.examples) {
     const inputs: string[] = [];
     for (const input of schema.cpp.function.inputs) {
       inputs.push(`      .${input.name}{${example.inputs[input.name]}}`);

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -37,21 +37,19 @@ export function generateCppTest(
 
   const testCases: string[] = [];
 
-  for (const name of Object.keys(schema.examples)) {
+  for (const example of Object.values(schema.examples)) {
     const inputs: string[] = [];
     for (const input of schema.cpp.function.inputs) {
-      inputs.push(
-        `      .${input.name}{${schema.examples[name].inputs[input.name]}}`,
-      );
+      inputs.push(`      .${input.name}{${example.inputs[input.name]}}`);
     }
 
     const lines = [
       `  {`,
-      `    .name{"example ${name}"},`,
+      `    .name{"${example.name}"},`,
       `    .inputs{`,
       inputs.join(",\n"),
       `    },`,
-      `    .output{${schema.examples[name].output}}`,
+      `    .output{${example.output}}`,
       `  }`,
     ];
 

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -21,15 +21,13 @@ cpp:
     output: int
 
 examples:
-  1:
-    name: example 1
+  - name: example 1
     inputs:
       num1: 12
       num2: 5
     output: 17
 
-  2:
-    name: example 2
+  - name: example 2
     inputs:
       num1: -10
       num2: 4
@@ -53,8 +51,8 @@ examples:
         output: "int",
       },
     },
-    examples: {
-      1: {
+    examples: [
+      {
         name: "example 1",
         inputs: {
           num1: 12,
@@ -62,7 +60,7 @@ examples:
         },
         output: 17,
       },
-      2: {
+      {
         name: "example 2",
         inputs: {
           num1: -10,
@@ -70,6 +68,6 @@ examples:
         },
         output: -6,
       },
-    },
+    ],
   });
 });

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -22,12 +22,14 @@ cpp:
 
 examples:
   1:
+    name: example 1
     inputs:
       num1: 12
       num2: 5
     output: 17
 
   2:
+    name: example 2
     inputs:
       num1: -10
       num2: 4
@@ -53,6 +55,7 @@ examples:
     },
     examples: {
       1: {
+        name: "example 1",
         inputs: {
           num1: 12,
           num2: 5,
@@ -60,6 +63,7 @@ examples:
         output: 17,
       },
       2: {
+        name: "example 2",
         inputs: {
           num1: -10,
           num2: 4,

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -20,7 +20,7 @@ cpp:
         type: int
     output: int
 
-examples:
+cases:
   - name: example 1
     inputs:
       num1: 12
@@ -51,7 +51,7 @@ examples:
         output: "int",
       },
     },
-    examples: [
+    cases: [
       {
         name: "example 1",
         inputs: {

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -12,7 +12,7 @@ export interface Schema {
       output: string;
     };
   };
-  examples: {
+  cases: {
     name: string;
     inputs: { [key: string]: unknown };
     output: unknown;

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -14,6 +14,7 @@ export interface Schema {
   };
   examples: {
     [key: string]: {
+      name: string;
       inputs: { [key: string]: unknown };
       output: unknown;
     };

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -13,12 +13,10 @@ export interface Schema {
     };
   };
   examples: {
-    [key: string]: {
-      name: string;
-      inputs: { [key: string]: unknown };
-      output: unknown;
-    };
-  };
+    name: string;
+    inputs: { [key: string]: unknown };
+    output: unknown;
+  }[];
 }
 
 /**


### PR DESCRIPTION
This pull request resolves #90 by modifying the `examples` property in the test schema as follows:
- Renamed to `cases`.
- Holds an array of objects instead of a map of objects.
- Adds a `name` property to the object in each array item.