### PR TITLE
Modify Property for Specifying Function Output Type in Schema

### DIFF
--- a/sample/problems/1688/test.yaml
+++ b/sample/problems/1688/test.yaml
@@ -4,7 +4,8 @@ cpp:
     inputs:
       - name: n
         type: int
-    output: int
+    output:
+      type: int
 
 cases:
   - name: example 1

--- a/sample/problems/2235/test.yaml
+++ b/sample/problems/2235/test.yaml
@@ -6,7 +6,8 @@ cpp:
         type: int
       - name: num2
         type: int
-    output: int
+    output:
+      type: int
 
 cases:
   - name: example 1

--- a/src/test/cpp.test.ts
+++ b/src/test/cpp.test.ts
@@ -34,7 +34,7 @@ it("should create a task for testing a C++ solution", async () => {
           { name: "num1", type: "int" },
           { name: "num2", type: "int" },
         ],
-        output: "int",
+        output: { type: "int" },
       },
     },
     cases: [

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -19,7 +19,7 @@ it("should generate a C++ test file", async () => {
           { name: "num1", type: "int" },
           { name: "num2", type: "int" },
         ],
-        output: "int",
+        output: { type: "int" },
       },
     },
     cases: [

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -30,7 +30,7 @@ export function generateCppTest(
       (input) => `    const ${input.type} ${input.name};`,
     ),
     `  } inputs;`,
-    `  const ${schema.cpp.function.output} output;`,
+    `  const ${schema.cpp.function.output.type} output;`,
     `};`,
     ``,
   ]);
@@ -76,7 +76,7 @@ export function generateCppTest(
     params.push(`t.inputs.${input.name}`);
   }
   lines.push(
-    `    const ${schema.cpp.function.output} output{s.${schema.cpp.function.name}(${params.join(", ")})};`,
+    `    const ${schema.cpp.function.output.type} output{s.${schema.cpp.function.name}(${params.join(", ")})};`,
   );
 
   lines = lines.concat([

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -18,7 +18,8 @@ cpp:
         type: int
       - name: num2
         type: int
-    output: int
+    output:
+      type: int
 
 cases:
   - name: example 1
@@ -48,7 +49,7 @@ cases:
           { name: "num1", type: "int" },
           { name: "num2", type: "int" },
         ],
-        output: "int",
+        output: { type: "int" },
       },
     },
     cases: [

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -9,7 +9,9 @@ export interface Schema {
         name: string;
         type: string;
       }[];
-      output: string;
+      output: {
+        type: string;
+      };
     };
   };
   cases: {


### PR DESCRIPTION
This pull request resolves #102 by modifying the property for specifying the function output type in the test schema to use the `cpp.function.output.type` property.