### PR TITLE
Sort Solution Files That Will Be Tested

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -16,7 +16,7 @@ yargs(hideBin(process.argv))
     async () => {
       const solutionFiles = globSync("**/solution.cpp");
       const task = new Listr(
-        solutionFiles.map(
+        solutionFiles.sort().map(
           (solutionFile): ListrTask => ({
             title: `Testing ${solutionFile}...`,
             task: (ctx, task) =>


### PR DESCRIPTION
This pull request resolves #108 by sorting the solution files after globbing, effectively ensuring that the solution files are tested in the correct order.