### PR TITLE
Fix Subtask Concurrency

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -21,6 +21,7 @@ yargs(hideBin(process.argv))
             title: `Testing ${solutionFile}...`,
             task: (ctx, task) =>
               task.newListr(createTestCppSolutionTasks(solutionFile), {
+                concurrent: false,
                 exitOnError: true,
               }),
           }),


### PR DESCRIPTION
This pull request resolves #118 by disabling concurrency in the sub tasks.