### PR TITLE
Run Test Sample Job in Workflow on All Platforms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,11 @@ jobs:
 
   test-sample:
     name: Test Sample
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.2


### PR DESCRIPTION
This pull request resolves #127 by modifying the Test Sample job in the workflow to run on all major platforms, including Windows, Ubuntu, and macOS.