### PR TITLE
Compile C++ Solution With Level Two Optimization

### DIFF
--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -28,7 +28,7 @@ it("should compile a C++ test file", async () => {
     recursive: true,
   });
   expect(execSync).toHaveBeenCalledExactlyOnceWith(
-    "clang++ --std=c++20 path/to/test.cpp -o build/path/to/test",
+    "clang++ --std=c++20 -O2 path/to/test.cpp -o build/path/to/test",
     { stdio: "pipe" },
   );
   expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -11,5 +11,7 @@ import path from "node:path";
 export function compileCppTest(testFile: string, outFile: string): void {
   mkdirSync(path.dirname(outFile), { recursive: true });
 
-  execSync(`clang++ --std=c++20 ${testFile} -o ${outFile}`, { stdio: "pipe" });
+  execSync(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`, {
+    stdio: "pipe",
+  });
 }


### PR DESCRIPTION
This pull request resolves #129 by adding the `-O2` option to the `clang++` command to compile C++ solutions with level two optimization.