### PR TITLE
Fix Run C++ Test Command on Windows

### DIFF
--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -9,9 +9,25 @@ it("should run a C++ test executable", async () => {
   const { execSync } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
+  jest.mocked(execSync).mockClear();
+
   runCppTest("build/path/to/test");
 
   expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
+    stdio: "pipe",
+  });
+});
+
+it("should run a C++ test executable on Windows", async () => {
+  const { execSync } = await import("node:child_process");
+  const { runCppTest } = await import("./run.js");
+
+  jest.mocked(execSync).mockClear();
+  Object.defineProperty(process, "platform", { value: "win32" });
+
+  runCppTest("build/path/to/test");
+
+  expect(execSync).toHaveBeenCalledExactlyOnceWith("start build/path/to/test", {
     stdio: "pipe",
   });
 });

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -6,5 +6,6 @@ import { execSync } from "node:child_process";
  * @param testExec - The path of the C++ test executable to run.
  */
 export function runCppTest(testExec: string): void {
-  execSync(testExec, { stdio: "pipe" });
+  const cmd = process.platform === "win32" ? `start ${testExec}` : testExec;
+  execSync(cmd, { stdio: "pipe" });
 }


### PR DESCRIPTION
This pull request resolves #134 by fixing the command for running the C++ test on Windows.