### PR TITLE
Add Support for Using `std::string` Type

### DIFF
--- a/sample/problems/1903/solution.cpp
+++ b/sample/problems/1903/solution.cpp
@@ -1,0 +1,13 @@
+#include <string>
+
+class Solution {
+ public:
+  std::string largestOddNumber(std::string num) {
+    for (std::size_t i = num.size(); i > 0; --i) {
+      if ((num[i - 1] - '0') % 2 != 1) continue;
+      return num.substr(0, i);
+    }
+
+    return "";
+  }
+};

--- a/sample/problems/1903/test.yaml
+++ b/sample/problems/1903/test.yaml
@@ -1,0 +1,24 @@
+cpp:
+  function:
+    name: largestOddNumber
+    inputs:
+      - type: std::string
+        value: num
+    output:
+      type: std::string
+
+cases:
+  - name: example 1
+    inputs:
+      num: "52"
+    output: "5"
+
+  - name: example 2
+    inputs:
+      num: "4206"
+    output: ""
+
+  - name: example 3
+    inputs:
+      num: "35427"
+    output: "35427"

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -7,6 +7,18 @@ jest.unstable_mockModule("node:fs", () => ({
   writeFileSync: jest.fn(),
 }));
 
+describe("format values in C++ format", () => {
+  it("should format an integer", async () => {
+    const { formatCpp } = await import("./generate.js");
+    expect(formatCpp(123, "int")).toBe("123");
+  });
+
+  it("should format a string", async () => {
+    const { formatCpp } = await import("./generate.js");
+    expect(formatCpp("something", "std::string")).toBe(`"something"`);
+  });
+});
+
 it("should generate a C++ test file", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
   const { generateCppTest } = await import("./generate.js");

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -3,6 +3,21 @@ import path from "node:path";
 import { Schema } from "../schema.js";
 
 /**
+ * Formats a value to a string in C++ format.
+ *
+ * @param value - The value to format.
+ * @param type - The target C++ type.
+ * @returns A string representation of the value in C++ format.
+ */
+export function formatCpp(value: unknown, type: string): string {
+  switch (type) {
+    case "std::string":
+      return `"${value}"`;
+  }
+  return `${value}`;
+}
+
+/**
  * Generates a C++ test file from a test schema.
  *
  * @param schema - The test schema.
@@ -42,10 +57,10 @@ export function generateCppTest(
       `    "${c.name}",`,
       `    .inputs{`,
       schema.cpp.function.inputs
-        .map((input) => `      ${c.inputs[input.value]}`)
+        .map((input) => `      ${formatCpp(c.inputs[input.value], input.type)}`)
         .join(",\n"),
       `    },`,
-      `    ${c.output}`,
+      `    ${formatCpp(c.output, schema.cpp.function.output.type)}`,
       `  }`,
     ];
 


### PR DESCRIPTION
This pull request resolves #138 by adding the problem [1903. Largest Odd Number in String](https://leetcode.com/problems/largest-odd-number-in-string/) to the sample problems and adding a `formatCpp` function for formatting test case values to a string in C++ format. The `formatCpp` function supports formatting a `std::string` type.