### PR TITLE
Add Support for Using `std::vector` Type

### DIFF
--- a/sample/problems/0001/solution.cpp
+++ b/sample/problems/0001/solution.cpp
@@ -1,0 +1,14 @@
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<int> twoSum(std::vector<int>& nums, int target) {
+    const int n = nums.size();
+    for (int i = 0; i < n; ++i) {
+      for (int j = i + 1; j < n; ++j) {
+        if (nums[i] + nums[j] == target) return {i, j};
+      }
+    }
+    return {0, 0};
+  }
+};

--- a/sample/problems/0001/test.yaml
+++ b/sample/problems/0001/test.yaml
@@ -1,0 +1,29 @@
+cpp:
+  function:
+    name: twoSum
+    inputs:
+      - type: std::vector<int>
+        value: nums
+      - type: int
+        value: target
+    output:
+      type: std::vector<int>
+
+cases:
+  - name: example 1
+    inputs:
+      nums: [2, 7, 11, 15]
+      target: 9
+    output: [0, 1]
+
+  - name: example 2
+    inputs:
+      nums: [3, 2, 4]
+      target: 6
+    output: [1, 2]
+
+  - name: example 3
+    inputs:
+      nums: [3, 3]
+      target: 6
+    output: [0, 1]

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -15,10 +15,15 @@ jest.unstable_mockModule("./generate/test_case.js", () => ({
   generateCppTestCaseCode: jest.fn(),
 }));
 
+jest.unstable_mockModule("./generate/utility.js", () => ({
+  generateCppUtilityCode: jest.fn(),
+}));
+
 it("should generate a C++ test file", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
   const { generateCppMainCode } = await import("./generate/main.js");
   const { generateCppTestCaseCode } = await import("./generate/test_case.js");
+  const { generateCppUtilityCode } = await import("./generate/utility.js");
   const { generateCppTest } = await import("./generate.js");
 
   const schema: Schema = {
@@ -58,6 +63,7 @@ it("should generate a C++ test file", async () => {
   });
 
   jest.mocked(generateCppTestCaseCode).mockReturnValue("// C++ test case code");
+  jest.mocked(generateCppUtilityCode).mockReturnValue("// C++ utility code");
 
   generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp");
 
@@ -75,6 +81,7 @@ it("should generate a C++ test file", async () => {
       `#include <utility>`,
       ``,
       `// C++ test case code`,
+      `// C++ utility code`,
       `// C++ main function code`,
     ].join("\n"),
   );

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Schema } from "../schema.js";
 import { generateCppMainCode } from "./generate/main.js";
+import { generateCppUtilityCode } from "./generate/utility.js";
 import { generateCppTestCaseCode } from "./generate/test_case.js";
 
 /**
@@ -30,6 +31,7 @@ export function generateCppTest(
         .join("\n"),
       ``,
       generateCppTestCaseCode(schema),
+      generateCppUtilityCode(schema),
       main.code,
     ].join("\n"),
   );

--- a/src/test/cpp/generate/format.test.ts
+++ b/src/test/cpp/generate/format.test.ts
@@ -8,4 +8,10 @@ describe("format values in C++ format", () => {
   it("should format a string", () => {
     expect(formatCpp("something", "std::string")).toBe(`"something"`);
   });
+
+  it("should format an array", () => {
+    expect(formatCpp([123, 234, 345], "std::vector<int>")).toBe(
+      "{123, 234, 345}",
+    );
+  });
 });

--- a/src/test/cpp/generate/format.ts
+++ b/src/test/cpp/generate/format.ts
@@ -9,6 +9,8 @@ export function formatCpp(value: unknown, type: string): string {
   switch (type) {
     case "std::string":
       return `"${value}"`;
+    case "std::vector<int>":
+      return `{${(value as unknown[]).map((x) => `${x}`).join(", ")}}`;
   }
   return `${value}`;
 }

--- a/src/test/cpp/generate/utility.test.ts
+++ b/src/test/cpp/generate/utility.test.ts
@@ -1,0 +1,34 @@
+import {
+  generateCppUtilityCode,
+  cppVectorOfIntOstreamOperatorCode,
+} from "./utility.js";
+
+import "jest-extended";
+
+it("should generate empty code for functions that return `int`", () => {
+  const code = generateCppUtilityCode({
+    cpp: {
+      function: {
+        name: "",
+        inputs: [],
+        output: { type: "int" },
+      },
+    },
+    cases: [],
+  });
+  expect(code).toBeEmpty();
+});
+
+it("should generate ostream operator code for functions that return `std::vector<int>`", () => {
+  const code = generateCppUtilityCode({
+    cpp: {
+      function: {
+        name: "",
+        inputs: [],
+        output: { type: "std::vector<int>" },
+      },
+    },
+    cases: [],
+  });
+  expect(code).toBe(cppVectorOfIntOstreamOperatorCode);
+});

--- a/src/test/cpp/generate/utility.ts
+++ b/src/test/cpp/generate/utility.ts
@@ -1,0 +1,29 @@
+import { Schema } from "../../schema.js";
+
+export const cppVectorOfIntOstreamOperatorCode = [
+  `std::ostream& operator<<(std::ostream& out, const std::vector<int>& arr) {`,
+  `  out << '{';`,
+  `  if (arr.size() > 0) {`,
+  `    out << arr[0];`,
+  `    for (std::size_t i{1}; i < arr.size(); ++i) {`,
+  `      out << ", " << arr[i];`,
+  `    }`,
+  `  }`,
+  `  return out << '}';`,
+  `}`,
+  ``,
+].join("\n");
+
+/**
+ * Generates C++ utility functions code from a test schema.
+ *
+ * @param schema - The test schema.
+ * @returns The generated C++ utility functions code.
+ */
+export function generateCppUtilityCode(schema: Schema): string {
+  if (schema.cpp.function.output.type === "std::vector<int>") {
+    return cppVectorOfIntOstreamOperatorCode;
+  }
+
+  return "";
+}


### PR DESCRIPTION
This pull request resolves #139 by introducing the following changes:
- Adds problem [1. Two Sum](https://leetcode.com/problems/two-sum) to the sample problems because it contains functions with `std::vector` inputs and output.
- Adds support in the `formatCpp` function to format values to the `std::vector<int>` type.
- Adds a new `generateCppUtilityCode` function that currently behaves by generating an ostream operator for a `std::vector<int>` type if the return type of the solution function is a `std::vector<int>`. This function is open for supporting other utilities in the future.