### PR TITLE
Organize Function for Generating C++ Test Files

### DIFF
--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -7,18 +7,6 @@ jest.unstable_mockModule("node:fs", () => ({
   writeFileSync: jest.fn(),
 }));
 
-describe("format values in C++ format", () => {
-  it("should format an integer", async () => {
-    const { formatCpp } = await import("./generate.js");
-    expect(formatCpp(123, "int")).toBe("123");
-  });
-
-  it("should format a string", async () => {
-    const { formatCpp } = await import("./generate.js");
-    expect(formatCpp("something", "std::string")).toBe(`"something"`);
-  });
-});
-
 it("should generate a C++ test file", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
   const { generateCppTest } = await import("./generate.js");

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -7,8 +7,18 @@ jest.unstable_mockModule("node:fs", () => ({
   writeFileSync: jest.fn(),
 }));
 
+jest.unstable_mockModule("./generate/main.js", () => ({
+  generateCppMainCode: jest.fn(),
+}));
+
+jest.unstable_mockModule("./generate/test_case.js", () => ({
+  generateCppTestCaseCode: jest.fn(),
+}));
+
 it("should generate a C++ test file", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { generateCppMainCode } = await import("./generate/main.js");
+  const { generateCppTestCaseCode } = await import("./generate/test_case.js");
   const { generateCppTest } = await import("./generate.js");
 
   const schema: Schema = {
@@ -42,6 +52,9 @@ it("should generate a C++ test file", async () => {
     ],
   };
 
+  jest.mocked(generateCppMainCode).mockReturnValue("// C++ main function code");
+  jest.mocked(generateCppTestCaseCode).mockReturnValue("// C++ test case code");
+
   generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp");
 
   expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
@@ -49,61 +62,15 @@ it("should generate a C++ test file", async () => {
   });
 
   expect(writeFileSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
-  expect(writeFileSync).toHaveBeenCalledOnce();
-
-  const writeFileSyncCall = jest.mocked(writeFileSync).mock.calls[0];
-  expect(writeFileSyncCall[0]).toBe("build/path/to/test.cpp");
-  expect(writeFileSyncCall[1]).toBe(
+  expect(writeFileSync).toHaveBeenCalledExactlyOnceWith(
+    "build/path/to/test.cpp",
     [
       `#include "../../../path/to/solution.cpp"`,
       ``,
       `#include <iostream>`,
       ``,
-      `struct TestCase {`,
-      `  const char* name;`,
-      `  struct {`,
-      `    int arg0;`,
-      `    int arg1;`,
-      `  } inputs;`,
-      `  int output;`,
-      `};`,
-      ``,
-      `TestCase test_cases[2]{`,
-      `  {`,
-      `    "example 1",`,
-      `    .inputs{`,
-      `      12,`,
-      `      5`,
-      `    },`,
-      `    17`,
-      `  },`,
-      `  {`,
-      `    "example 2",`,
-      `    .inputs{`,
-      `      -10,`,
-      `      4`,
-      `    },`,
-      `    -6`,
-      `  }`,
-      `};`,
-      ``,
-      `int main() {`,
-      `  int failures{0};`,
-      `  for (int i{0}; i < 2; ++i) {`,
-      `    std::cout << "testing " << test_cases[i].name << "...\\n";`,
-      `    Solution s{};`,
-      `    const int output{s.sum(test_cases[i].inputs.arg0, test_cases[i].inputs.arg1)};`,
-      `    if (output != test_cases[i].output) {`,
-      `      std::cerr << "failed to test " << test_cases[i].name << ":\\n";`,
-      `      std::cerr << ".  output: " << output << "\\n";`,
-      `      std::cerr << ".  expected: " << test_cases[i].output << "\\n\\n";`,
-      `      ++failures;`,
-      `    }`,
-      `  }`,
-      `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
-      `  return failures;`,
-      `}`,
-      ``,
+      `// C++ test case code`,
+      `// C++ main function code`,
     ].join("\n"),
   );
 });

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -1,21 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { Schema } from "../schema.js";
-
-/**
- * Formats a value to a string in C++ format.
- *
- * @param value - The value to format.
- * @param type - The target C++ type.
- * @returns A string representation of the value in C++ format.
- */
-export function formatCpp(value: unknown, type: string): string {
-  switch (type) {
-    case "std::string":
-      return `"${value}"`;
-  }
-  return `${value}`;
-}
+import { formatCpp } from "./generate/format.js";
 
 /**
  * Generates a C++ test file from a test schema.

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -16,15 +16,16 @@ export function generateCppTest(
   solutionFile: string,
   outFile: string,
 ): void {
-  const lines: string[] = [
-    `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,
-    ``,
-    `#include <iostream>`,
-    ``,
-    generateCppTestCaseCode(schema),
-    generateCppMainCode(schema),
-  ];
-
   mkdirSync(path.dirname(outFile), { recursive: true });
-  writeFileSync(outFile, lines.join("\n"));
+  writeFileSync(
+    outFile,
+    [
+      `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,
+      ``,
+      `#include <iostream>`,
+      ``,
+      generateCppTestCaseCode(schema),
+      generateCppMainCode(schema),
+    ].join("\n"),
+  );
 }

--- a/src/test/cpp/generate/format.test.ts
+++ b/src/test/cpp/generate/format.test.ts
@@ -1,0 +1,11 @@
+import { formatCpp } from "./format.js";
+
+describe("format values in C++ format", () => {
+  it("should format an integer", () => {
+    expect(formatCpp(123, "int")).toBe("123");
+  });
+
+  it("should format a string", () => {
+    expect(formatCpp("something", "std::string")).toBe(`"something"`);
+  });
+});

--- a/src/test/cpp/generate/format.ts
+++ b/src/test/cpp/generate/format.ts
@@ -1,0 +1,14 @@
+/**
+ * Formats a value to a string in C++ format.
+ *
+ * @param value - The value to format.
+ * @param type - The target C++ type.
+ * @returns A string representation of the value in C++ format.
+ */
+export function formatCpp(value: unknown, type: string): string {
+  switch (type) {
+    case "std::string":
+      return `"${value}"`;
+  }
+  return `${value}`;
+}

--- a/src/test/cpp/generate/main.test.ts
+++ b/src/test/cpp/generate/main.test.ts
@@ -1,0 +1,55 @@
+import { generateCppMainCode } from "./main.js";
+
+it("should generate a C++ main function code", () => {
+  const code = generateCppMainCode({
+    cpp: {
+      function: {
+        name: "sum",
+        inputs: [
+          { type: "int", value: "num1" },
+          { type: "int", value: "num2" },
+        ],
+        output: { type: "int" },
+      },
+    },
+    cases: [
+      {
+        name: "example 1",
+        inputs: {
+          num1: 12,
+          num2: 5,
+        },
+        output: 17,
+      },
+      {
+        name: "example 2",
+        inputs: {
+          num1: -10,
+          num2: 4,
+        },
+        output: -6,
+      },
+    ],
+  });
+  expect(code).toBe(
+    [
+      `int main() {`,
+      `  int failures{0};`,
+      `  for (int i{0}; i < 2; ++i) {`,
+      `    std::cout << "testing " << test_cases[i].name << "...\\n";`,
+      `    Solution s{};`,
+      `    const int output{s.sum(test_cases[i].inputs.arg0, test_cases[i].inputs.arg1)};`,
+      `    if (output != test_cases[i].output) {`,
+      `      std::cerr << "failed to test " << test_cases[i].name << ":\\n";`,
+      `      std::cerr << ".  output: " << output << "\\n";`,
+      `      std::cerr << ".  expected: " << test_cases[i].output << "\\n\\n";`,
+      `      ++failures;`,
+      `    }`,
+      `  }`,
+      `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
+      `  return failures;`,
+      `}`,
+      ``,
+    ].join("\n"),
+  );
+});

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,0 +1,34 @@
+import { Schema } from "../../schema.js";
+
+/**
+ * Generates C++ main function code from a test schema.
+ *
+ * @param schema - The test schema.
+ * @returns The generated C++ main function code.
+ */
+export function generateCppMainCode(schema: Schema): string {
+  return [
+    `int main() {`,
+    `  int failures{0};`,
+    `  for (int i{0}; i < ${schema.cases.length}; ++i) {`,
+    `    std::cout << "testing " << test_cases[i].name << "...\\n";`,
+    `    Solution s{};`,
+    (() => {
+      const params = schema.cpp.function.inputs
+        .map((_, i) => `test_cases[i].inputs.arg${i}`)
+        .join(", ");
+      return `    const ${schema.cpp.function.output.type} output{s.${schema.cpp.function.name}(${params})};`;
+    })(),
+    `    if (output != test_cases[i].output) {`,
+    `      std::cerr << "failed to test " << test_cases[i].name << ":\\n";`,
+    `      std::cerr << ".  output: " << output << "\\n";`,
+    `      std::cerr << ".  expected: " << test_cases[i].output << "\\n\\n";`,
+    `      ++failures;`,
+    `    }`,
+    `  }`,
+    `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
+    `  return failures;`,
+    `}`,
+    ``,
+  ].join("\n");
+}

--- a/src/test/cpp/generate/test_case.test.ts
+++ b/src/test/cpp/generate/test_case.test.ts
@@ -1,0 +1,66 @@
+import { generateCppTestCaseCode } from "./test_case.js";
+
+it("should generate a C++ test case code", () => {
+  const code = generateCppTestCaseCode({
+    cpp: {
+      function: {
+        name: "sum",
+        inputs: [
+          { type: "int", value: "num1" },
+          { type: "int", value: "num2" },
+        ],
+        output: { type: "int" },
+      },
+    },
+    cases: [
+      {
+        name: "example 1",
+        inputs: {
+          num1: 12,
+          num2: 5,
+        },
+        output: 17,
+      },
+      {
+        name: "example 2",
+        inputs: {
+          num1: -10,
+          num2: 4,
+        },
+        output: -6,
+      },
+    ],
+  });
+  expect(code).toBe(
+    [
+      `struct TestCase {`,
+      `  const char* name;`,
+      `  struct {`,
+      `    int arg0;`,
+      `    int arg1;`,
+      `  } inputs;`,
+      `  int output;`,
+      `};`,
+      ``,
+      `TestCase test_cases[2]{`,
+      `  {`,
+      `    "example 1",`,
+      `    .inputs{`,
+      `      12,`,
+      `      5`,
+      `    },`,
+      `    17`,
+      `  },`,
+      `  {`,
+      `    "example 2",`,
+      `    .inputs{`,
+      `      -10,`,
+      `      4`,
+      `    },`,
+      `    -6`,
+      `  }`,
+      `};`,
+      ``,
+    ].join("\n"),
+  );
+});

--- a/src/test/cpp/generate/test_case.ts
+++ b/src/test/cpp/generate/test_case.ts
@@ -1,0 +1,44 @@
+import { Schema } from "../../schema.js";
+import { formatCpp } from "./format.js";
+
+/**
+ * Generates C++ test case code from a test schema.
+ *
+ * @param schema - The test schema.
+ * @returns The generated C++ test case code.
+ */
+export function generateCppTestCaseCode(schema: Schema): string {
+  return [
+    `struct TestCase {`,
+    `  const char* name;`,
+    `  struct {`,
+    ...schema.cpp.function.inputs.map(
+      (input, i) => `    ${input.type} arg${i};`,
+    ),
+    `  } inputs;`,
+    `  ${schema.cpp.function.output.type} output;`,
+    `};`,
+    ``,
+    `TestCase test_cases[${schema.cases.length}]{`,
+    schema.cases
+      .map((c) =>
+        [
+          `  {`,
+          `    "${c.name}",`,
+          `    .inputs{`,
+          schema.cpp.function.inputs
+            .map(
+              (input) =>
+                `      ${formatCpp(c.inputs[input.value], input.type)}`,
+            )
+            .join(",\n"),
+          `    },`,
+          `    ${formatCpp(c.output, schema.cpp.function.output.type)}`,
+          `  }`,
+        ].join("\n"),
+      )
+      .join(",\n"),
+    `};`,
+    ``,
+  ].join("\n");
+}


### PR DESCRIPTION
This pull request resolves #145 by separating the `generateCppTest` function into several functions in the `generate` directory and adjusting the testing accordingly. It also moves the `formatCpp` function to the `generate` directory.