### PR TITLE
Specify Header Requirements for Each Generated C++ Code Function

### DIFF
--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -54,7 +54,7 @@ it("should generate a C++ test file", async () => {
 
   jest.mocked(generateCppMainCode).mockReturnValue({
     code: "// C++ main function code",
-    headers: new Set(["iostream"]),
+    headers: new Set(["iostream", "utility"]),
   });
 
   jest.mocked(generateCppTestCaseCode).mockReturnValue("// C++ test case code");
@@ -72,6 +72,7 @@ it("should generate a C++ test file", async () => {
       `#include "../../../path/to/solution.cpp"`,
       ``,
       `#include <iostream>`,
+      `#include <utility>`,
       ``,
       `// C++ test case code`,
       `// C++ main function code`,

--- a/src/test/cpp/generate.test.ts
+++ b/src/test/cpp/generate.test.ts
@@ -52,7 +52,11 @@ it("should generate a C++ test file", async () => {
     ],
   };
 
-  jest.mocked(generateCppMainCode).mockReturnValue("// C++ main function code");
+  jest.mocked(generateCppMainCode).mockReturnValue({
+    code: "// C++ main function code",
+    headers: new Set(["iostream"]),
+  });
+
   jest.mocked(generateCppTestCaseCode).mockReturnValue("// C++ test case code");
 
   generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp");

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -16,16 +16,21 @@ export function generateCppTest(
   solutionFile: string,
   outFile: string,
 ): void {
+  const main = generateCppMainCode(schema);
+
   mkdirSync(path.dirname(outFile), { recursive: true });
   writeFileSync(
     outFile,
     [
       `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,
       ``,
-      `#include <iostream>`,
+      [...main.headers]
+        .sort()
+        .map((header) => `#include <${header}>`)
+        .join("\n"),
       ``,
       generateCppTestCaseCode(schema),
-      generateCppMainCode(schema).code,
+      main.code,
     ].join("\n"),
   );
 }

--- a/src/test/cpp/generate.ts
+++ b/src/test/cpp/generate.ts
@@ -25,7 +25,7 @@ export function generateCppTest(
       `#include <iostream>`,
       ``,
       generateCppTestCaseCode(schema),
-      generateCppMainCode(schema),
+      generateCppMainCode(schema).code,
     ].join("\n"),
   );
 }

--- a/src/test/cpp/generate/main.test.ts
+++ b/src/test/cpp/generate/main.test.ts
@@ -1,7 +1,7 @@
 import { generateCppMainCode } from "./main.js";
 
 it("should generate a C++ main function code", () => {
-  const code = generateCppMainCode({
+  const { code, headers } = generateCppMainCode({
     cpp: {
       function: {
         name: "sum",
@@ -31,6 +31,7 @@ it("should generate a C++ main function code", () => {
       },
     ],
   });
+
   expect(code).toBe(
     [
       `int main() {`,
@@ -52,4 +53,5 @@ it("should generate a C++ main function code", () => {
       ``,
     ].join("\n"),
   );
+  expect([...headers]).toStrictEqual(["iostream"]);
 });

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -4,31 +4,37 @@ import { Schema } from "../../schema.js";
  * Generates C++ main function code from a test schema.
  *
  * @param schema - The test schema.
- * @returns The generated C++ main function code.
+ * @returns An object containing the generated C++ code and a set of required headers.
  */
-export function generateCppMainCode(schema: Schema): string {
-  return [
-    `int main() {`,
-    `  int failures{0};`,
-    `  for (int i{0}; i < ${schema.cases.length}; ++i) {`,
-    `    std::cout << "testing " << test_cases[i].name << "...\\n";`,
-    `    Solution s{};`,
-    (() => {
-      const params = schema.cpp.function.inputs
-        .map((_, i) => `test_cases[i].inputs.arg${i}`)
-        .join(", ");
-      return `    const ${schema.cpp.function.output.type} output{s.${schema.cpp.function.name}(${params})};`;
-    })(),
-    `    if (output != test_cases[i].output) {`,
-    `      std::cerr << "failed to test " << test_cases[i].name << ":\\n";`,
-    `      std::cerr << ".  output: " << output << "\\n";`,
-    `      std::cerr << ".  expected: " << test_cases[i].output << "\\n\\n";`,
-    `      ++failures;`,
-    `    }`,
-    `  }`,
-    `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
-    `  return failures;`,
-    `}`,
-    ``,
-  ].join("\n");
+export function generateCppMainCode(schema: Schema): {
+  code: string;
+  headers: Set<string>;
+} {
+  return {
+    code: [
+      `int main() {`,
+      `  int failures{0};`,
+      `  for (int i{0}; i < ${schema.cases.length}; ++i) {`,
+      `    std::cout << "testing " << test_cases[i].name << "...\\n";`,
+      `    Solution s{};`,
+      (() => {
+        const params = schema.cpp.function.inputs
+          .map((_, i) => `test_cases[i].inputs.arg${i}`)
+          .join(", ");
+        return `    const ${schema.cpp.function.output.type} output{s.${schema.cpp.function.name}(${params})};`;
+      })(),
+      `    if (output != test_cases[i].output) {`,
+      `      std::cerr << "failed to test " << test_cases[i].name << ":\\n";`,
+      `      std::cerr << ".  output: " << output << "\\n";`,
+      `      std::cerr << ".  expected: " << test_cases[i].output << "\\n\\n";`,
+      `      ++failures;`,
+      `    }`,
+      `  }`,
+      `  if (failures > 0) std::cerr << failures << " test cases have failed\\n";`,
+      `  return failures;`,
+      `}`,
+      ``,
+    ].join("\n"),
+    headers: new Set(["iostream"]),
+  };
 }


### PR DESCRIPTION
This pull request resolves #147 by introducing the following changes:
- Modifying the `generateCppMainCode` function to return required headers alongside the C++ code.
- Modifying the `generateCppTest` function to declare the headers to include based on the required headers from the `generateCppMainCode` function.