### PR TITLE
Organize Source Files by Shifting Files with Directories

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import yargs from "yargs";
 import { globSync } from "glob";
 import { Listr, ListrTask } from "listr2";
 import { hideBin } from "yargs/helpers";
-import { createTestCppSolutionTasks } from "./test/cpp.js";
+import { createTestCppSolutionTasks } from "./test/cpp/index.js";
 
 yargs(hideBin(process.argv))
   .scriptName("leettest")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { createTestCppSolutionTasks } from "./test/cpp.js";
+export { createTestCppSolutionTasks } from "./test/cpp/index.js";
 export { readYamlSchema, Schema } from "./test/schema.js";

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -1,5 +1,5 @@
 import { jest } from "@jest/globals";
-import { Schema } from "../schema.js";
+import { Schema } from "../../schema.js";
 import "jest-extended";
 
 jest.unstable_mockModule("node:fs", () => ({
@@ -7,24 +7,24 @@ jest.unstable_mockModule("node:fs", () => ({
   writeFileSync: jest.fn(),
 }));
 
-jest.unstable_mockModule("./generate/main.js", () => ({
+jest.unstable_mockModule("./main.js", () => ({
   generateCppMainCode: jest.fn(),
 }));
 
-jest.unstable_mockModule("./generate/test_case.js", () => ({
+jest.unstable_mockModule("./test_case.js", () => ({
   generateCppTestCaseCode: jest.fn(),
 }));
 
-jest.unstable_mockModule("./generate/utility.js", () => ({
+jest.unstable_mockModule("./utility.js", () => ({
   generateCppUtilityCode: jest.fn(),
 }));
 
 it("should generate a C++ test file", async () => {
   const { mkdirSync, writeFileSync } = await import("node:fs");
-  const { generateCppMainCode } = await import("./generate/main.js");
-  const { generateCppTestCaseCode } = await import("./generate/test_case.js");
-  const { generateCppUtilityCode } = await import("./generate/utility.js");
-  const { generateCppTest } = await import("./generate.js");
+  const { generateCppMainCode } = await import("./main.js");
+  const { generateCppTest } = await import("./index.js");
+  const { generateCppTestCaseCode } = await import("./test_case.js");
+  const { generateCppUtilityCode } = await import("./utility.js");
 
   const schema: Schema = {
     cpp: {

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,9 +1,9 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { Schema } from "../schema.js";
-import { generateCppMainCode } from "./generate/main.js";
-import { generateCppUtilityCode } from "./generate/utility.js";
-import { generateCppTestCaseCode } from "./generate/test_case.js";
+import { Schema } from "../../schema.js";
+import { generateCppMainCode } from "./main.js";
+import { generateCppUtilityCode } from "./utility.js";
+import { generateCppTestCaseCode } from "./test_case.js";
 
 /**
  * Generates a C++ test file from a test schema.

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -1,30 +1,30 @@
 import { jest } from "@jest/globals";
 import { Listr } from "listr2";
-import { Schema } from "./schema.js";
+import { Schema } from "../schema.js";
 import "jest-extended";
 
-jest.unstable_mockModule("./cpp/compile.js", () => ({
-  compileCppTest: jest.fn(),
-}));
-
-jest.unstable_mockModule("./cpp/generate.js", () => ({
-  generateCppTest: jest.fn(),
-}));
-
-jest.unstable_mockModule("./cpp/run.js", () => ({
-  runCppTest: jest.fn(),
-}));
-
-jest.unstable_mockModule("./schema.js", () => ({
+jest.unstable_mockModule("../schema.js", () => ({
   readYamlSchema: jest.fn(),
 }));
 
+jest.unstable_mockModule("./compile.js", () => ({
+  compileCppTest: jest.fn(),
+}));
+
+jest.unstable_mockModule("./generate.js", () => ({
+  generateCppTest: jest.fn(),
+}));
+
+jest.unstable_mockModule("./run.js", () => ({
+  runCppTest: jest.fn(),
+}));
+
 it("should create a task for testing a C++ solution", async () => {
-  const { compileCppTest } = await import("./cpp/compile.js");
-  const { generateCppTest } = await import("./cpp/generate.js");
-  const { runCppTest } = await import("./cpp/run.js");
-  const { createTestCppSolutionTasks } = await import("./cpp.js");
-  const { readYamlSchema } = await import("./schema.js");
+  const { readYamlSchema } = await import("../schema.js");
+  const { generateCppTest } = await import("./generate/index.js");
+  const { compileCppTest } = await import("./compile.js");
+  const { createTestCppSolutionTasks } = await import("./index.js");
+  const { runCppTest } = await import("./run.js");
 
   const schema: Schema = {
     cpp: {

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -1,9 +1,9 @@
 import { ListrTask } from "listr2";
 import path from "node:path";
-import { compileCppTest } from "./cpp/compile.js";
-import { generateCppTest } from "./cpp/generate.js";
-import { runCppTest } from "./cpp/run.js";
-import { readYamlSchema, Schema } from "./schema.js";
+import { readYamlSchema, Schema } from "../schema.js";
+import { generateCppTest } from "./generate/index.js";
+import { compileCppTest } from "./compile.js";
+import { runCppTest } from "./run.js";
 
 /**
  * Creates a list of tasks for testing the C++ solution of a LeetCode problem.


### PR DESCRIPTION
This pull request resolves #151 by shifting source files with a directory to be moved inside that directory and be renamed to `index.ts`.