### PR TITLE
Extend Support for Handling `std::vector<T>` When Generating C++ Test

### DIFF
--- a/sample/problems/appendStringsArrays/solution.cpp
+++ b/sample/problems/appendStringsArrays/solution.cpp
@@ -1,0 +1,10 @@
+#include <string>
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<std::string> appendStringsArrays(std::vector<std::string> strs1, std::vector<std::string> strs2) {
+    strs1.insert(strs1.end(), strs2.begin(), strs2.end());
+    return strs1;
+  }
+};

--- a/sample/problems/appendStringsArrays/test.yaml
+++ b/sample/problems/appendStringsArrays/test.yaml
@@ -1,0 +1,29 @@
+cpp:
+  function:
+    name: appendStringsArrays
+    inputs:
+      - type: std::vector<std::string>
+        value: strs1
+      - type: std::vector<std::string>
+        value: strs2
+    output:
+      type: std::vector<std::string>
+
+cases:
+  - name: example 1
+    inputs:
+      strs1: [foo, bar]
+      strs2: [foo, baz]
+    output: [foo, bar, foo, baz]
+
+  - name: example 2
+    inputs:
+      strs1: [foo, bar, baz]
+      strs2: [foo, bar]
+    output: [foo, bar, baz, foo, bar]
+
+  - name: example 2
+    inputs:
+      strs1: [foo, bar]
+      strs2: []
+    output: [foo, bar]

--- a/src/test/cpp/generate/format.test.ts
+++ b/src/test/cpp/generate/format.test.ts
@@ -9,9 +9,15 @@ describe("format values in C++ format", () => {
     expect(formatCpp("something", "std::string")).toBe(`"something"`);
   });
 
-  it("should format an array", () => {
+  it("should format an array of integers", () => {
     expect(formatCpp([123, 234, 345], "std::vector<int>")).toBe(
       "{123, 234, 345}",
+    );
+  });
+
+  it("should format an array of strings", () => {
+    expect(formatCpp(["foo", "bar", "baz"], "std::vector<std::string>")).toBe(
+      `{"foo", "bar", "baz"}`,
     );
   });
 });

--- a/src/test/cpp/generate/format.ts
+++ b/src/test/cpp/generate/format.ts
@@ -6,11 +6,14 @@
  * @returns A string representation of the value in C++ format.
  */
 export function formatCpp(value: unknown, type: string): string {
-  switch (type) {
-    case "std::string":
-      return `"${value}"`;
-    case "std::vector<int>":
-      return `{${(value as unknown[]).map((x) => `${x}`).join(", ")}}`;
+  if (type === "std::string") {
+    return `"${value}"`;
   }
+
+  if (type.match(/^std::vector<.*>$/)) {
+    const subtype = type.substring(12, type.length - 1);
+    return `{${(value as unknown[]).map((v) => formatCpp(v, subtype)).join(", ")}}`;
+  }
+
   return `${value}`;
 }

--- a/src/test/cpp/generate/utility.test.ts
+++ b/src/test/cpp/generate/utility.test.ts
@@ -1,6 +1,6 @@
 import {
   generateCppUtilityCode,
-  cppVectorOfIntOstreamOperatorCode,
+  cppVectorOstreamOperatorCode,
 } from "./utility.js";
 
 import "jest-extended";
@@ -30,5 +30,5 @@ it("should generate ostream operator code for functions that return `std::vector
     },
     cases: [],
   });
-  expect(code).toBe(cppVectorOfIntOstreamOperatorCode);
+  expect(code).toBe(cppVectorOstreamOperatorCode);
 });

--- a/src/test/cpp/generate/utility.ts
+++ b/src/test/cpp/generate/utility.ts
@@ -1,7 +1,8 @@
 import { Schema } from "../../schema.js";
 
-export const cppVectorOfIntOstreamOperatorCode = [
-  `std::ostream& operator<<(std::ostream& out, const std::vector<int>& arr) {`,
+export const cppVectorOstreamOperatorCode = [
+  `template <typename T>`,
+  `std::ostream& operator<<(std::ostream& out, const std::vector<T>& arr) {`,
   `  out << '{';`,
   `  if (arr.size() > 0) {`,
   `    out << arr[0];`,
@@ -21,8 +22,8 @@ export const cppVectorOfIntOstreamOperatorCode = [
  * @returns The generated C++ utility functions code.
  */
 export function generateCppUtilityCode(schema: Schema): string {
-  if (schema.cpp.function.output.type === "std::vector<int>") {
-    return cppVectorOfIntOstreamOperatorCode;
+  if (schema.cpp.function.output.type.match(/^std::vector<.*>$/)) {
+    return cppVectorOstreamOperatorCode;
   }
 
   return "";


### PR DESCRIPTION
This pull request resolves #153 by extending support for handling the `std::vector` type when generating C++ tests to accommodate any type of `std::vector<T>`, not limited to just the `std::vector<int>` type.