### PR TITLE
Cast Test Schema Type in Generate Test Function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { testCppSolution } from "./test/cpp/index.js";
-export { readYamlSchema, Schema } from "./test/schema.js";
+export { readYamlSchema } from "./test/schema.js";

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { Schema } from "../../schema.js";
 import "jest-extended";
 
 jest.unstable_mockModule("node:fs", () => ({
@@ -26,7 +25,7 @@ it("should generate a C++ test file", async () => {
   const { generateCppTestCaseCode } = await import("./test_case.js");
   const { generateCppUtilityCode } = await import("./utility.js");
 
-  const schema: Schema = {
+  const schema = {
     cpp: {
       function: {
         name: "sum",

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,9 +1,8 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { Schema } from "../../schema.js";
 import { generateCppMainCode } from "./main.js";
 import { generateCppUtilityCode } from "./utility.js";
-import { generateCppTestCaseCode } from "./test_case.js";
+import { CppTestCaseSchema, generateCppTestCaseCode } from "./test_case.js";
 
 /**
  * Generates a C++ test file from a test schema.
@@ -13,11 +12,13 @@ import { generateCppTestCaseCode } from "./test_case.js";
  * @param outFile - The path of the C++ test file output.
  */
 export function generateCppTest(
-  schema: Schema,
+  schema: unknown,
   solutionFile: string,
   outFile: string,
 ): void {
-  const main = generateCppMainCode(schema);
+  const cppTestSchema = schema as CppTestCaseSchema;
+
+  const main = generateCppMainCode(cppTestSchema);
 
   mkdirSync(path.dirname(outFile), { recursive: true });
   writeFileSync(
@@ -30,8 +31,8 @@ export function generateCppTest(
         .map((header) => `#include <${header}>`)
         .join("\n"),
       ``,
-      generateCppTestCaseCode(schema),
-      generateCppUtilityCode(schema),
+      generateCppTestCaseCode(cppTestSchema),
+      generateCppUtilityCode(cppTestSchema),
       main.code,
     ].join("\n"),
   );

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,12 +1,12 @@
-import { Schema } from "../../schema.js";
+import type { CppTestCaseSchema } from "./test_case.js";
 
 /**
- * Generates C++ main function code from a test schema.
+ * Generates C++ main function code from a C++ test case schema.
  *
- * @param schema - The test schema.
+ * @param schema - The C++ test case schema.
  * @returns An object containing the generated C++ code and a set of required headers.
  */
-export function generateCppMainCode(schema: Schema): {
+export function generateCppMainCode(schema: CppTestCaseSchema): {
   code: string;
   headers: Set<string>;
 } {

--- a/src/test/cpp/generate/test_case.ts
+++ b/src/test/cpp/generate/test_case.ts
@@ -1,13 +1,32 @@
-import { Schema } from "../../schema.js";
 import { formatCpp } from "./format.js";
 
+export interface CppTestCaseSchema {
+  cpp: {
+    function: {
+      name: string;
+      inputs: {
+        type: string;
+        value: string;
+      }[];
+      output: {
+        type: string;
+      };
+    };
+  };
+  cases: {
+    name: string;
+    inputs: { [key: string]: unknown };
+    output: unknown;
+  }[];
+}
+
 /**
- * Generates C++ test case code from a test schema.
+ * Generates C++ test case code from a C++ test case schema.
  *
- * @param schema - The test schema.
+ * @param schema - The C++ test case schema.
  * @returns The generated C++ test case code.
  */
-export function generateCppTestCaseCode(schema: Schema): string {
+export function generateCppTestCaseCode(schema: CppTestCaseSchema): string {
   return [
     `struct TestCase {`,
     `  const char* name;`,

--- a/src/test/cpp/generate/utility.ts
+++ b/src/test/cpp/generate/utility.ts
@@ -1,4 +1,4 @@
-import { Schema } from "../../schema.js";
+import type { CppTestCaseSchema } from "./test_case.js";
 
 export const cppVectorOstreamOperatorCode = [
   `template <typename T>`,
@@ -16,12 +16,12 @@ export const cppVectorOstreamOperatorCode = [
 ].join("\n");
 
 /**
- * Generates C++ utility functions code from a test schema.
+ * Generates C++ utility functions code from a C++ test case schema.
  *
- * @param schema - The test schema.
+ * @param schema - The C++ test case schema.
  * @returns The generated C++ utility functions code.
  */
-export function generateCppUtilityCode(schema: Schema): string {
+export function generateCppUtilityCode(schema: CppTestCaseSchema): string {
   if (schema.cpp.function.output.type.match(/^std::vector<.*>$/)) {
     return cppVectorOstreamOperatorCode;
   }

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -1,5 +1,4 @@
 import { jest } from "@jest/globals";
-import { Schema } from "../schema.js";
 import "jest-extended";
 
 jest.unstable_mockModule("../schema.js", () => ({
@@ -25,7 +24,7 @@ it("should test a C++ solution", async () => {
   const { testCppSolution } = await import("./index.js");
   const { runCppTest } = await import("./run.js");
 
-  const schema: Schema = {
+  const schema = {
     cpp: {
       function: {
         name: "sum",

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -1,33 +1,13 @@
 import { readFileSync } from "node:fs";
 import YAML from "yaml";
 
-export interface Schema {
-  cpp: {
-    function: {
-      name: string;
-      inputs: {
-        type: string;
-        value: string;
-      }[];
-      output: {
-        type: string;
-      };
-    };
-  };
-  cases: {
-    name: string;
-    inputs: { [key: string]: unknown };
-    output: unknown;
-  }[];
-}
-
 /**
  * Reads a test schema from a YAML file.
  *
  * @param schemaFile - The path of the YAML schema file.
- * @returns The parsed test schema.
+ * @returns The parsed test schema of unknown type.
  */
-export function readYamlSchema(schemaFile: string): Schema {
+export function readYamlSchema(schemaFile: string): unknown {
   const data = readFileSync(schemaFile, "utf-8");
   return YAML.parse(data);
 }


### PR DESCRIPTION
This pull request resolves #158.

TODO:
- [ ] wait for `generateCppUtilityCode` to be replaced by return value like headers.