### PR TITLE
Use Asynchronous Node.js Functions

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -27,7 +27,7 @@ yargs(hideBin(process.argv))
 
       const tests = solutionFiles.map((file) => ({
         file: file,
-        prom: (async () => testCppSolution(file))(),
+        prom: testCppSolution(file),
       }));
 
       let failures = 0;

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -5,33 +5,33 @@ jest.unstable_mockModule("node:child_process", () => ({
   execSync: jest.fn(),
 }));
 
-jest.unstable_mockModule("node:fs", () => ({
-  mkdirSync: jest.fn(),
+jest.unstable_mockModule("node:fs/promises", () => ({
+  mkdir: jest.fn(),
 }));
 
 beforeEach(async () => {
   const { execSync } = await import("node:child_process");
-  const { mkdirSync } = await import("node:fs");
+  const { mkdir } = await import("node:fs/promises");
 
   jest.mocked(execSync).mockClear();
-  jest.mocked(mkdirSync).mockClear();
+  jest.mocked(mkdir).mockClear();
 });
 
 it("should compile a C++ test file", async () => {
   const { execSync } = await import("node:child_process");
-  const { mkdirSync } = await import("node:fs");
+  const { mkdir } = await import("node:fs/promises");
   const { compileCppTest } = await import("./compile.js");
 
   await expect(
     compileCppTest("path/to/test.cpp", "build/path/to/test"),
   ).resolves.toBeUndefined();
 
-  expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
+  expect(mkdir).toHaveBeenCalledExactlyOnceWith("build/path/to", {
     recursive: true,
   });
   expect(execSync).toHaveBeenCalledExactlyOnceWith(
     "clang++ --std=c++20 -O2 path/to/test.cpp -o build/path/to/test",
     { stdio: "pipe" },
   );
-  expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
+  expect(execSync).toHaveBeenCalledAfter(jest.mocked(mkdir));
 });

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -22,7 +22,9 @@ it("should compile a C++ test file", async () => {
   const { mkdirSync } = await import("node:fs");
   const { compileCppTest } = await import("./compile.js");
 
-  compileCppTest("path/to/test.cpp", "build/path/to/test");
+  await expect(
+    compileCppTest("path/to/test.cpp", "build/path/to/test"),
+  ).resolves.toBeUndefined();
 
   expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
     recursive: true,

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -7,8 +7,12 @@ import path from "node:path";
  *
  * @param testFile - The path of the C++ test file to compile.
  * @param outFile - The path of the compiled executable output.
+ * @returns A promise that resolves to nothing.
  */
-export function compileCppTest(testFile: string, outFile: string): void {
+export async function compileCppTest(
+  testFile: string,
+  outFile: string,
+): Promise<void> {
   mkdirSync(path.dirname(outFile), { recursive: true });
 
   execSync(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`, {

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -1,6 +1,9 @@
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
 import { mkdir } from "node:fs/promises";
+import { promisify } from "node:util";
 import path from "node:path";
+
+const execPromise = promisify(exec);
 
 /**
  * Compiles a C++ test file using Clang.
@@ -14,8 +17,5 @@ export async function compileCppTest(
   outFile: string,
 ): Promise<void> {
   await mkdir(path.dirname(outFile), { recursive: true });
-
-  execSync(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`, {
-    stdio: "pipe",
-  });
+  await execPromise(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`);
 }

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -13,7 +13,7 @@ export async function compileCppTest(
   testFile: string,
   outFile: string,
 ): Promise<void> {
-  mkdirSync(path.dirname(outFile), { recursive: true });
+  await mkdir(path.dirname(outFile), { recursive: true });
 
   execSync(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`, {
     stdio: "pipe",

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -65,7 +65,9 @@ it("should generate a C++ test file", async () => {
   jest.mocked(generateCppTestCaseCode).mockReturnValue("// C++ test case code");
   jest.mocked(generateCppUtilityCode).mockReturnValue("// C++ utility code");
 
-  generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp");
+  await expect(
+    generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp"),
+  ).resolves.toBeUndefined();
 
   expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
     recursive: true,

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -3,8 +3,11 @@ import { Schema } from "../../schema.js";
 import "jest-extended";
 
 jest.unstable_mockModule("node:fs", () => ({
-  mkdirSync: jest.fn(),
   writeFileSync: jest.fn(),
+}));
+
+jest.unstable_mockModule("node:fs/promises", () => ({
+  mkdir: jest.fn(),
 }));
 
 jest.unstable_mockModule("./main.js", () => ({
@@ -20,7 +23,8 @@ jest.unstable_mockModule("./utility.js", () => ({
 }));
 
 it("should generate a C++ test file", async () => {
-  const { mkdirSync, writeFileSync } = await import("node:fs");
+  const { writeFileSync } = await import("node:fs");
+  const { mkdir } = await import("node:fs/promises");
   const { generateCppMainCode } = await import("./main.js");
   const { generateCppTest } = await import("./index.js");
   const { generateCppTestCaseCode } = await import("./test_case.js");
@@ -69,11 +73,11 @@ it("should generate a C++ test file", async () => {
     generateCppTest(schema, "path/to/solution.cpp", "build/path/to/test.cpp"),
   ).resolves.toBeUndefined();
 
-  expect(mkdirSync).toHaveBeenCalledExactlyOnceWith("build/path/to", {
+  expect(mkdir).toHaveBeenCalledExactlyOnceWith("build/path/to", {
     recursive: true,
   });
 
-  expect(writeFileSync).toHaveBeenCalledAfter(jest.mocked(mkdirSync));
+  expect(writeFileSync).toHaveBeenCalledAfter(jest.mocked(mkdir));
   expect(writeFileSync).toHaveBeenCalledExactlyOnceWith(
     "build/path/to/test.cpp",
     [

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -2,12 +2,9 @@ import { jest } from "@jest/globals";
 import { Schema } from "../../schema.js";
 import "jest-extended";
 
-jest.unstable_mockModule("node:fs", () => ({
-  writeFileSync: jest.fn(),
-}));
-
 jest.unstable_mockModule("node:fs/promises", () => ({
   mkdir: jest.fn(),
+  writeFile: jest.fn(),
 }));
 
 jest.unstable_mockModule("./main.js", () => ({
@@ -23,8 +20,7 @@ jest.unstable_mockModule("./utility.js", () => ({
 }));
 
 it("should generate a C++ test file", async () => {
-  const { writeFileSync } = await import("node:fs");
-  const { mkdir } = await import("node:fs/promises");
+  const { mkdir, writeFile } = await import("node:fs/promises");
   const { generateCppMainCode } = await import("./main.js");
   const { generateCppTest } = await import("./index.js");
   const { generateCppTestCaseCode } = await import("./test_case.js");
@@ -77,8 +73,8 @@ it("should generate a C++ test file", async () => {
     recursive: true,
   });
 
-  expect(writeFileSync).toHaveBeenCalledAfter(jest.mocked(mkdir));
-  expect(writeFileSync).toHaveBeenCalledExactlyOnceWith(
+  expect(writeFile).toHaveBeenCalledAfter(jest.mocked(mkdir));
+  expect(writeFile).toHaveBeenCalledExactlyOnceWith(
     "build/path/to/test.cpp",
     [
       `#include "../../../path/to/solution.cpp"`,

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,5 +1,4 @@
-import { writeFileSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { Schema } from "../../schema.js";
 import { generateCppMainCode } from "./main.js";
@@ -22,7 +21,7 @@ export async function generateCppTest(
   const main = generateCppMainCode(schema);
 
   await mkdir(path.dirname(outFile), { recursive: true });
-  writeFileSync(
+  await writeFile(
     outFile,
     [
       `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -11,12 +11,13 @@ import { generateCppTestCaseCode } from "./test_case.js";
  * @param schema - The test schema.
  * @param solutionFile - The path of the C++ solution file.
  * @param outFile - The path of the C++ test file output.
+ * @returns A promise that resolves to nothing.
  */
-export function generateCppTest(
+export async function generateCppTest(
   schema: Schema,
   solutionFile: string,
   outFile: string,
-): void {
+): Promise<void> {
   const main = generateCppMainCode(schema);
 
   mkdirSync(path.dirname(outFile), { recursive: true });

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { Schema } from "../../schema.js";
 import { generateCppMainCode } from "./main.js";
@@ -20,7 +21,7 @@ export async function generateCppTest(
 ): Promise<void> {
   const main = generateCppMainCode(schema);
 
-  mkdirSync(path.dirname(outFile), { recursive: true });
+  await mkdir(path.dirname(outFile), { recursive: true });
   writeFileSync(
     outFile,
     [

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -56,7 +56,7 @@ it("should test a C++ solution", async () => {
     ],
   };
 
-  jest.mocked(readYamlSchema).mockReturnValue(schema);
+  jest.mocked(readYamlSchema).mockResolvedValue(schema);
 
   await expect(
     testCppSolution("path/to/solution.cpp"),

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -58,7 +58,9 @@ it("should test a C++ solution", async () => {
 
   jest.mocked(readYamlSchema).mockReturnValue(schema);
 
-  expect(() => testCppSolution("path/to/solution.cpp")).not.toThrow();
+  await expect(
+    testCppSolution("path/to/solution.cpp"),
+  ).resolves.toBeUndefined();
 
   expect(readYamlSchema).toHaveBeenCalledExactlyOnceWith("path/to/test.yaml");
 

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -15,7 +15,7 @@ import { runCppTest } from "./run.js";
  */
 export async function testCppSolution(solutionFile: string): Promise<void> {
   const schemaFile = path.join(path.dirname(solutionFile), "test.yaml");
-  const schema = readYamlSchema(schemaFile);
+  const schema = await readYamlSchema(schemaFile);
 
   const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
   await generateCppTest(schema, solutionFile, testFile);

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -21,7 +21,7 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   generateCppTest(schema, solutionFile, testFile);
 
   const testExec = path.join(path.dirname(testFile), "test");
-  compileCppTest(testFile, testExec);
+  await compileCppTest(testFile, testExec);
 
   runCppTest(testExec);
 }

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -23,5 +23,5 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   const testExec = path.join(path.dirname(testFile), "test");
   await compileCppTest(testFile, testExec);
 
-  runCppTest(testExec);
+  await runCppTest(testExec);
 }

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -18,7 +18,7 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   const schema = readYamlSchema(schemaFile);
 
   const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
-  generateCppTest(schema, solutionFile, testFile);
+  await generateCppTest(schema, solutionFile, testFile);
 
   const testExec = path.join(path.dirname(testFile), "test");
   await compileCppTest(testFile, testExec);

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -11,8 +11,9 @@ import { runCppTest } from "./run.js";
  * and then runs the executable for testing the solution.
  *
  * @param solutionFile - The path of the C++ solution file.
+ * @returns A promise that resolves to nothing.
  */
-export function testCppSolution(solutionFile: string): void {
+export async function testCppSolution(solutionFile: string): Promise<void> {
   const schemaFile = path.join(path.dirname(solutionFile), "test.yaml");
   const schema = readYamlSchema(schemaFile);
 

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -11,7 +11,7 @@ it("should run a C++ test executable", async () => {
 
   jest.mocked(execSync).mockClear();
 
-  runCppTest("build/path/to/test");
+  await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
   expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
     stdio: "pipe",
@@ -25,7 +25,7 @@ it("should run a C++ test executable on Windows", async () => {
   jest.mocked(execSync).mockClear();
   Object.defineProperty(process, "platform", { value: "win32" });
 
-  runCppTest("build/path/to/test");
+  await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
   expect(execSync).toHaveBeenCalledExactlyOnceWith("start build/path/to/test", {
     stdio: "pipe",

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -2,32 +2,28 @@ import { jest } from "@jest/globals";
 import "jest-extended";
 
 jest.unstable_mockModule("node:child_process", () => ({
-  execSync: jest.fn(),
+  exec: jest.fn((_, callback: () => void) => callback()),
 }));
 
 it("should run a C++ test executable", async () => {
-  const { execSync } = await import("node:child_process");
+  const { exec } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
-  jest.mocked(execSync).mockClear();
+  jest.mocked(exec).mockClear();
 
   await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
-  expect(execSync).toHaveBeenCalledExactlyOnceWith("build/path/to/test", {
-    stdio: "pipe",
-  });
+  expect(jest.mocked(exec).mock.calls[0][0]).toBe("build/path/to/test");
 });
 
 it("should run a C++ test executable on Windows", async () => {
-  const { execSync } = await import("node:child_process");
+  const { exec } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
-  jest.mocked(execSync).mockClear();
+  jest.mocked(exec).mockClear();
   Object.defineProperty(process, "platform", { value: "win32" });
 
   await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
-  expect(execSync).toHaveBeenCalledExactlyOnceWith("start build/path/to/test", {
-    stdio: "pipe",
-  });
+  expect(jest.mocked(exec).mock.calls[0][0]).toBe("start build/path/to/test");
 });

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -4,8 +4,9 @@ import { execSync } from "node:child_process";
  * Runs a C++ test executable.
  *
  * @param testExec - The path of the C++ test executable to run.
+ * @returns A promise that resolves to nothing.
  */
-export function runCppTest(testExec: string): void {
+export async function runCppTest(testExec: string): Promise<void> {
   const cmd = process.platform === "win32" ? `start ${testExec}` : testExec;
   execSync(cmd, { stdio: "pipe" });
 }

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -1,4 +1,7 @@
-import { execSync } from "node:child_process";
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const execPromise = promisify(exec);
 
 /**
  * Runs a C++ test executable.
@@ -7,6 +10,7 @@ import { execSync } from "node:child_process";
  * @returns A promise that resolves to nothing.
  */
 export async function runCppTest(testExec: string): Promise<void> {
-  const cmd = process.platform === "win32" ? `start ${testExec}` : testExec;
-  execSync(cmd, { stdio: "pipe" });
+  await execPromise(
+    process.platform === "win32" ? `start ${testExec}` : testExec,
+  );
 }

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -35,13 +35,7 @@ cases:
     output: -6
   `);
 
-  const schema = readYamlSchema("path/to/test.yaml");
-
-  expect(readFileSync).toHaveBeenCalledExactlyOnceWith(
-    "path/to/test.yaml",
-    "utf-8",
-  );
-  expect(schema).toStrictEqual({
+  await expect(readYamlSchema("path/to/test.yaml")).resolves.toStrictEqual({
     cpp: {
       function: {
         name: "sum",
@@ -71,4 +65,9 @@ cases:
       },
     ],
   });
+
+  expect(readFileSync).toHaveBeenCalledExactlyOnceWith(
+    "path/to/test.yaml",
+    "utf-8",
+  );
 });

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1,15 +1,15 @@
 import { jest } from "@jest/globals";
 import "jest-extended";
 
-jest.unstable_mockModule("node:fs", () => ({
-  readFileSync: jest.fn(),
+jest.unstable_mockModule("node:fs/promises", () => ({
+  readFile: jest.fn(),
 }));
 
 it("should read a YAML schema file", async () => {
-  const { readFileSync } = await import("node:fs");
+  const { readFile } = await import("node:fs/promises");
   const { readYamlSchema } = await import("./schema.js");
 
-  jest.mocked(readFileSync).mockReturnValue(`
+  jest.mocked(readFile).mockResolvedValue(`
 cpp:
   function:
     name: sum
@@ -66,7 +66,7 @@ cases:
     ],
   });
 
-  expect(readFileSync).toHaveBeenCalledExactlyOnceWith(
+  expect(readFile).toHaveBeenCalledExactlyOnceWith(
     "path/to/test.yaml",
     "utf-8",
   );

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -25,9 +25,9 @@ export interface Schema {
  * Reads a test schema from a YAML file.
  *
  * @param schemaFile - The path of the YAML schema file.
- * @returns The parsed test schema.
+ * @returns A promise that resolves to the parsed test schema.
  */
-export function readYamlSchema(schemaFile: string): Schema {
+export async function readYamlSchema(schemaFile: string): Promise<Schema> {
   const data = readFileSync(schemaFile, "utf-8");
   return YAML.parse(data);
 }

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import YAML from "yaml";
 
 export interface Schema {
@@ -28,6 +28,6 @@ export interface Schema {
  * @returns A promise that resolves to the parsed test schema.
  */
 export async function readYamlSchema(schemaFile: string): Promise<Schema> {
-  const data = readFileSync(schemaFile, "utf-8");
+  const data = await readFile(schemaFile, "utf-8");
   return YAML.parse(data);
 }


### PR DESCRIPTION
This pull request resolves #174 by introducing the following changes:
- Modifying the following functions to be asynchronous: `testCppSolution`, `compileCppTest`, `generateCppTest`, `runCppTest`, `readYamlSchema`.
- Utilizing the asynchronous versions of the following Node.js functions: `mkdirSync`, `execSync`, `writeFileSync`, `readFileSync`.