### PR TITLE
Run ESLint with No File Arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "format": "prettier --write --cache .",
-    "lint": "eslint .",
+    "lint": "eslint",
     "prepack": "tsc",
     "start": "tsx src/bin.ts",
     "test": "jest"


### PR DESCRIPTION
This pull request simply resolves #180 by modifying the `lint` script in the `package.json` file to run the `eslint` command with no file arguments.