### PR TITLE
Add Generate Assertion Code Function

### DIFF
--- a/src/generate/cpp/assertion.test.ts
+++ b/src/generate/cpp/assertion.test.ts
@@ -1,0 +1,93 @@
+import { jest } from "@jest/globals";
+import { createTempDirectory, ITempDirectory } from "create-temp-directory";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { compileCppSource } from "../../compile/cpp.js";
+import { runExecutable } from "../../run.js";
+import { indentCode } from "../utils.js";
+import { generateCppEqualityAssertionCode } from "./assertions.js";
+import { generateCppIncludeHeadersCode } from "./headers.js";
+
+jest.retryTimes(10);
+
+describe("generate C++ code for asserting the equality of two variables", () => {
+  it.concurrent("should generate C++ code", () => {
+    const { code, requiredHeaders } = generateCppEqualityAssertionCode(
+      "actualVar",
+      "expectedVar",
+    );
+    expect(code).toEqual(
+      [
+        `if (actualVar != expectedVar) {`,
+        `  std::stringstream ss{};`,
+        `  ss << "  actual: " << actualVar << "\\n";`,
+        `  ss << "  expected: " << expectedVar;`,
+        `  throw std::runtime_error(ss.str());`,
+        `}`,
+      ].join("\n"),
+    );
+    expect([...requiredHeaders].sort()).toEqual(["sstream", "stdexcept"]);
+  });
+
+  describe("compile and run the generated code", () => {
+    const testDirs: ITempDirectory[] = [];
+    const getTestDir = async () => {
+      const testDir = await createTempDirectory();
+      testDirs.push(testDir);
+      return testDir;
+    };
+
+    const writeTestMainFile = async (
+      actual: number,
+      expected: number,
+    ): Promise<string> => {
+      const testDir = await getTestDir();
+      const equalityAssertion = generateCppEqualityAssertionCode(
+        "actualVar",
+        "expectedVar",
+      );
+      const mainFile = path.join(testDir.path, "main.cpp");
+      await fs.writeFile(
+        mainFile,
+        [
+          generateCppIncludeHeadersCode(
+            new Set<string>(["iostream", ...equalityAssertion.requiredHeaders]),
+          ),
+          ``,
+          `int main() {`,
+          `  int actualVar{${actual}};`,
+          `  int expectedVar{${expected}};`,
+          indentCode(equalityAssertion.code, "  "),
+          `  return 0;`,
+          `};`,
+          ``,
+        ].join("\n"),
+      );
+      return mainFile;
+    };
+
+    it.concurrent(
+      "should successfully assert two equal variables",
+      async () => {
+        const mainFile = await writeTestMainFile(123, 123);
+        const exeFile = await compileCppSource(mainFile);
+        await runExecutable(exeFile);
+      },
+      60000,
+    );
+
+    it.concurrent(
+      "should fail to assert two unequal variables",
+      async () => {
+        const mainFile = await writeTestMainFile(123, 234);
+        const exeFile = await compileCppSource(mainFile);
+        await expect(runExecutable(exeFile)).rejects.toThrow();
+      },
+      60000,
+    );
+
+    afterAll(async () => {
+      await Promise.all(testDirs.map((testDir) => testDir.remove()));
+    });
+  });
+});

--- a/src/generate/cpp/assertions.ts
+++ b/src/generate/cpp/assertions.ts
@@ -1,0 +1,26 @@
+/**
+ * Generates C++ code to assert the equality between two variables.
+ *
+ * @param actual - The name of the variable holding the actual value.
+ * @param expected - The name of the variable holding the expected value.
+ * @returns An object containing the generated C++ code and the required headers.
+ */
+export function generateCppEqualityAssertionCode(
+  actual: string,
+  expected: string,
+): {
+  code: string;
+  requiredHeaders: Set<string>;
+} {
+  return {
+    code: [
+      `if (${actual} != ${expected}) {`,
+      `  std::stringstream ss{};`,
+      `  ss << "  actual: " << ${actual} << "\\n";`,
+      `  ss << "  expected: " << ${expected};`,
+      `  throw std::runtime_error(ss.str());`,
+      `}`,
+    ].join("\n"),
+    requiredHeaders: new Set<string>(["sstream", "stdexcept"]),
+  };
+}


### PR DESCRIPTION
This pull request resolves #209 by refactoring the lines in the `generateCppMainCode` function that assert the equality of two variables into a separate function named `generateCppEqualityAssertionCode`.