### PR TITLE
Modify Compile C++ Testing to Compile Actual Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.7",
     "@types/yargs": "^17.0.32",
+    "create-temp-directory": "^2.4.0",
     "eslint": "^9.1.1",
     "jest": "^29.7.0",
     "jest-extended": "^4.0.2",

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -31,3 +31,21 @@ it("should compile a C++ test file", async () => {
 
   await fs.access(executablePath, fs.constants.X_OK);
 });
+
+it("should not compile an invalid C++ test file", async () => {
+  const sourcePath = path.join(testDir.path, "test.cpp");
+  await fs.writeFile(sourcePath, "int main() {");
+
+  const executablePath = path.join(testDir.path, "build", "test");
+  await expect(compileCppTest(sourcePath, executablePath)).rejects.toThrow(
+    /Command failed:[^]*1 error generated/,
+  );
+});
+
+it("should not compile a non-existing C++ test file", async () => {
+  const sourcePath = path.join(testDir.path, "test.cpp");
+  const executablePath = path.join(testDir.path, "build", "test");
+  await expect(compileCppTest(sourcePath, executablePath)).rejects.toThrow(
+    /Command failed:[^]*no such file or directory/,
+  );
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,6 +1816,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"create-temp-directory@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "create-temp-directory@npm:2.4.0"
+  checksum: 10c0/52d63e6208007c56b24986f064ec49ef7fc6c13d43c154714191a486ec86639cd30103de2c6724a427825bda3b7cb5441818e1f028893c8fea3d2ba912996495
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -3444,6 +3451,7 @@ __metadata:
     "@types/node": "npm:^20.12.7"
     "@types/yargs": "npm:^17.0.32"
     catched-error-message: "npm:^0.0.1"
+    create-temp-directory: "npm:^2.4.0"
     eslint: "npm:^9.1.1"
     glob: "npm:^10.3.12"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #216 by modifying tests for the `compileCppTest` function to compile actual code. It also tests edge cases when the function fails to compile the code.