### PR TITLE
Modify Running C++ Tests to Run Actual Executable

### DIFF
--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -1,7 +1,7 @@
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { compileCppTest } from "./compile.js";
+import { compileCppTest, getCppExecutablePath } from "./compile.js";
 import { runCppTest } from "./run.js";
 
 const testDirs: ITempDirectory[] = [];
@@ -22,6 +22,45 @@ it.concurrent(
     const executablePath = await compileCppTest(sourcePath);
 
     await runCppTest(executablePath);
+  },
+  60000,
+);
+
+it.concurrent(
+  "should run a failing C++ test executable",
+  async () => {
+    const testDir = await getTestDir();
+
+    const sourcePath = path.join(testDir.path, "test.cpp");
+    await fs.writeFile(
+      sourcePath,
+      [
+        `#include <iostream>`,
+        ``,
+        `int main() {`,
+        `  std::cerr << "unknown error\\n";`,
+        `  return 1;`,
+        `}`,
+      ].join("\n"),
+    );
+
+    const executablePath = await compileCppTest(sourcePath);
+
+    await expect(runCppTest(executablePath)).rejects.toThrow(
+      /Command failed:[^]*unknown error/,
+    );
+  },
+  60000,
+);
+
+it.concurrent(
+  "should not run a non-existing C++ test executable",
+  async () => {
+    const testDir = await getTestDir();
+    const executablePath = getCppExecutablePath(
+      path.join(testDir.path, "test"),
+    );
+    await expect(runCppTest(executablePath)).rejects.toThrow(/spawn.*ENOENT/);
   },
   60000,
 );


### PR DESCRIPTION
This pull request resolves #219 by modifying tests for the `runCppTest` function to execute the actual executable generated from the `compileCppTest` function.