### PR TITLE
Run Test Package Job on Multiple Platforms

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,11 @@ jobs:
 
   test-package:
     name: Test Package
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows, ubuntu, macos]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.4

--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -30,7 +30,7 @@ it("should compile a C++ test file", async () => {
   await compileCppTest(sourcePath, executablePath);
 
   await fs.access(executablePath, fs.constants.X_OK);
-});
+}, 60000);
 
 it("should not compile an invalid C++ test file", async () => {
   const sourcePath = path.join(testDir.path, "test.cpp");
@@ -40,7 +40,7 @@ it("should not compile an invalid C++ test file", async () => {
   await expect(compileCppTest(sourcePath, executablePath)).rejects.toThrow(
     /Command failed:[^]*1 error generated/,
   );
-});
+}, 60000);
 
 it("should not compile a non-existing C++ test file", async () => {
   const sourcePath = path.join(testDir.path, "test.cpp");
@@ -48,4 +48,4 @@ it("should not compile a non-existing C++ test file", async () => {
   await expect(compileCppTest(sourcePath, executablePath)).rejects.toThrow(
     /Command failed:[^]*no such file or directory/,
   );
-});
+}, 60000);

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import path from "node:path";
 import { Schema } from "../../schema.js";
 import "jest-extended";
 
@@ -77,7 +78,7 @@ it("should generate a C++ test file", async () => {
   expect(writeFile).toHaveBeenCalledExactlyOnceWith(
     "build/path/to/test.cpp",
     [
-      `#include "../../../path/to/solution.cpp"`,
+      `#include "${path.join("..", "..", "..", "path", "to", "solution.cpp")}"`,
       ``,
       `#include <iostream>`,
       `#include <utility>`,

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -1,4 +1,5 @@
 import { jest } from "@jest/globals";
+import path from "node:path";
 import { Schema } from "../schema.js";
 import "jest-extended";
 
@@ -59,24 +60,28 @@ it("should test a C++ solution", async () => {
   jest.mocked(readYamlSchema).mockResolvedValue(schema);
 
   await expect(
-    testCppSolution("path/to/solution.cpp"),
+    testCppSolution(path.join("path", "to", "solution.cpp")),
   ).resolves.toBeUndefined();
 
-  expect(readYamlSchema).toHaveBeenCalledExactlyOnceWith("path/to/test.yaml");
+  expect(readYamlSchema).toHaveBeenCalledExactlyOnceWith(
+    path.join("path", "to", "test.yaml"),
+  );
 
   expect(generateCppTest).toHaveBeenCalledAfter(jest.mocked(readYamlSchema));
   expect(generateCppTest).toHaveBeenCalledExactlyOnceWith(
     schema,
-    "path/to/solution.cpp",
-    "build/path/to/test.cpp",
+    path.join("path", "to", "solution.cpp"),
+    path.join("build", "path", "to", "test.cpp"),
   );
 
   expect(compileCppTest).toHaveBeenCalledAfter(jest.mocked(generateCppTest));
   expect(compileCppTest).toHaveBeenCalledExactlyOnceWith(
-    "build/path/to/test.cpp",
-    "build/path/to/test",
+    path.join("build", "path", "to", "test.cpp"),
+    path.join("build", "path", "to", "test"),
   );
 
   expect(runCppTest).toHaveBeenCalledAfter(jest.mocked(compileCppTest));
-  expect(runCppTest).toHaveBeenCalledExactlyOnceWith("build/path/to/test");
+  expect(runCppTest).toHaveBeenCalledExactlyOnceWith(
+    path.join("build", "path", "to", "test"),
+  );
 });

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -5,11 +5,12 @@ jest.unstable_mockModule("node:child_process", () => ({
   exec: jest.fn((_, callback: () => void) => callback()),
 }));
 
-it("should run a C++ test executable", async () => {
+it("should run a C++ test executable on Linux", async () => {
   const { exec } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
   jest.mocked(exec).mockClear();
+  Object.defineProperty(process, "platform", { value: "linux" });
 
   await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 


### PR DESCRIPTION
This pull request resolves #221 by introducing the following changes:
- Modifying the `test-package` job to run on all supported platforms.
- Increasing the timeout when testing C++ compilation.
- Fixing the C++ run testing for the Windows platform.
- Fixing the path for the Windows platform in testing.