### PR TITLE
Modify Compile C++ Function to Optionally Specify Output Directory

### DIFF
--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -26,8 +26,8 @@ it("should compile a C++ test file", async () => {
     ].join("\n"),
   );
 
-  const executablePath = path.join(testDir.path, "build", "test");
-  await compileCppTest(sourcePath, executablePath);
+  let executablePath = path.join(testDir.path, "build", "test");
+  executablePath = await compileCppTest(sourcePath, executablePath);
 
   await fs.access(executablePath, fs.constants.X_OK);
 }, 60000);

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -10,12 +10,13 @@ const execPromise = promisify(exec);
  *
  * @param testFile - The path of the C++ test file to compile.
  * @param outFile - The path of the compiled executable output.
- * @returns A promise that resolves to nothing.
+ * @returns A promise that resolves to the path of the compiled executable output.
  */
 export async function compileCppTest(
   testFile: string,
   outFile: string,
-): Promise<void> {
+): Promise<string> {
   await mkdir(path.dirname(outFile), { recursive: true });
   await execPromise(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`);
+  return outFile;
 }

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -9,14 +9,18 @@ const execPromise = promisify(exec);
  * Compiles a C++ test file using Clang.
  *
  * @param testFile - The path of the C++ test file to compile.
- * @param outFile - The path of the compiled executable output.
+ * @param outDir - An optional path for the compiled executable output directory.
  * @returns A promise that resolves to the path of the compiled executable output.
  */
 export async function compileCppTest(
   testFile: string,
-  outFile: string,
+  outDir?: string,
 ): Promise<string> {
-  await mkdir(path.dirname(outFile), { recursive: true });
+  let outFile = testFile.replace(path.extname(testFile), "");
+  if (outDir !== undefined) {
+    await mkdir(outDir, { recursive: true });
+    outFile = path.join(outDir, path.basename(outFile));
+  }
   await execPromise(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`);
   return outFile;
 }

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -58,7 +58,12 @@ it("should test a C++ solution", async () => {
   };
 
   jest.mocked(readYamlSchema).mockResolvedValue(schema);
-  jest.mocked(compileCppTest).mockImplementation(async (_, outFile) => outFile);
+  jest.mocked(compileCppTest).mockImplementation(async (testFile, outDir) => {
+    const outFile = testFile.replace(path.extname(testFile), "");
+    return outDir !== undefined
+      ? path.join(outDir, path.basename(outFile))
+      : outFile;
+  });
 
   await expect(
     testCppSolution(path.join("path", "to", "solution.cpp")),
@@ -78,7 +83,6 @@ it("should test a C++ solution", async () => {
   expect(compileCppTest).toHaveBeenCalledAfter(jest.mocked(generateCppTest));
   expect(compileCppTest).toHaveBeenCalledExactlyOnceWith(
     path.join("build", "path", "to", "test.cpp"),
-    path.join("build", "path", "to", "test"),
   );
 
   expect(runCppTest).toHaveBeenCalledAfter(jest.mocked(compileCppTest));

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -58,6 +58,7 @@ it("should test a C++ solution", async () => {
   };
 
   jest.mocked(readYamlSchema).mockResolvedValue(schema);
+  jest.mocked(compileCppTest).mockImplementation(async (_, outFile) => outFile);
 
   await expect(
     testCppSolution(path.join("path", "to", "solution.cpp")),

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -20,8 +20,8 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
   await generateCppTest(schema, solutionFile, testFile);
 
-  const testExec = path.join(path.dirname(testFile), "test");
-  await compileCppTest(testFile, testExec);
+  let testExec = path.join(path.dirname(testFile), "test");
+  testExec = await compileCppTest(testFile, testExec);
 
   await runCppTest(testExec);
 }

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -20,8 +20,7 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
   await generateCppTest(schema, solutionFile, testFile);
 
-  let testExec = path.join(path.dirname(testFile), "test");
-  testExec = await compileCppTest(testFile, testExec);
+  const testExec = await compileCppTest(testFile);
 
   await runCppTest(testExec);
 }


### PR DESCRIPTION
This pull request resolves #226 by modifying the `compileCppTest` function as follows:
- Modifies the function to return the path of the executable output.
- Replaces the `outFile` argument with an optional `outDir` argument for specifying the path of the executable output directory.