### PR TITLE
Modify C++ Compilation Output to Have `.exe` Extension on Windows

### DIFF
--- a/src/test/cpp/compile.test.ts
+++ b/src/test/cpp/compile.test.ts
@@ -3,16 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppTest, getCppExecutablePath } from "./compile.js";
 
-let testDir: ITempDirectory;
-
-beforeEach(async () => {
-  testDir = await createTempDirectory();
-});
-
-afterEach(async () => {
-  await testDir.remove();
-});
-
 describe("retrieve an executable path", () => {
   let originalProcessPlatform: string;
   beforeEach(() => (originalProcessPlatform = process.platform));
@@ -38,56 +28,62 @@ describe("retrieve an executable path", () => {
 });
 
 describe("compile a C++ test file", () => {
-  let sourcePath: string;
-  beforeEach(async () => {
-    sourcePath = path.join(testDir.path, "test.cpp");
-    await fs.writeFile(
-      sourcePath,
-      [
-        `#include <iostream>`,
-        ``,
-        `int main() {`,
-        `  std::cout << "Hello world!\\n";`,
-        `  return 0;`,
-        `}`,
-      ].join("\n"),
-    );
+  let testDir: ITempDirectory;
+  beforeEach(async () => (testDir = await createTempDirectory()));
+  afterEach(async () => await testDir.remove());
+
+  describe("compile a valid C++ test file", () => {
+    let sourcePath: string;
+    beforeEach(async () => {
+      sourcePath = path.join(testDir.path, "test.cpp");
+      await fs.writeFile(
+        sourcePath,
+        [
+          `#include <iostream>`,
+          ``,
+          `int main() {`,
+          `  std::cout << "Hello world!\\n";`,
+          `  return 0;`,
+          `}`,
+        ].join("\n"),
+      );
+    });
+
+    it("should compile a valid C++ test file", async () => {
+      const executablePath = await compileCppTest(sourcePath);
+
+      expect(executablePath).toBe(
+        getCppExecutablePath(path.join(testDir.path, "test")),
+      );
+      await fs.access(executablePath, fs.constants.X_OK);
+    }, 60000);
+
+    it("should compile a valid C++ test file to a specified directory", async () => {
+      const executablePath = await compileCppTest(
+        sourcePath,
+        path.join(testDir.path, "build"),
+      );
+
+      expect(executablePath).toBe(
+        getCppExecutablePath(path.join(testDir.path, "build", "test")),
+      );
+      await fs.access(executablePath, fs.constants.X_OK);
+    }, 60000);
   });
 
-  it("should compile a C++ test file", async () => {
-    const executablePath = await compileCppTest(sourcePath);
+  it("should not compile an invalid C++ test file", async () => {
+    const sourcePath = path.join(testDir.path, "test.cpp");
+    await fs.writeFile(sourcePath, "int main() {");
 
-    expect(executablePath).toBe(
-      getCppExecutablePath(path.join(testDir.path, "test")),
+    await expect(compileCppTest(sourcePath)).rejects.toThrow(
+      /Command failed:[^]*1 error generated/,
     );
-    await fs.access(executablePath, fs.constants.X_OK);
   }, 60000);
 
-  it("should compile a C++ test file to a specified directory", async () => {
-    const executablePath = await compileCppTest(
-      sourcePath,
-      path.join(testDir.path, "build"),
+  it("should not compile a non-existing C++ test file", async () => {
+    const sourcePath = path.join(testDir.path, "test.cpp");
+    await expect(compileCppTest(sourcePath)).rejects.toThrow(
+      /Command failed:[^]*no such file or directory/,
     );
-
-    expect(executablePath).toBe(
-      getCppExecutablePath(path.join(testDir.path, "build", "test")),
-    );
-    await fs.access(executablePath, fs.constants.X_OK);
   }, 60000);
 });
-
-it("should not compile an invalid C++ test file", async () => {
-  const sourcePath = path.join(testDir.path, "test.cpp");
-  await fs.writeFile(sourcePath, "int main() {");
-
-  await expect(compileCppTest(sourcePath)).rejects.toThrow(
-    /Command failed:[^]*1 error generated/,
-  );
-}, 60000);
-
-it("should not compile a non-existing C++ test file", async () => {
-  const sourcePath = path.join(testDir.path, "test.cpp");
-  await expect(compileCppTest(sourcePath)).rejects.toThrow(
-    /Command failed:[^]*no such file or directory/,
-  );
-}, 60000);

--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -6,6 +6,19 @@ import path from "node:path";
 const execPromise = promisify(exec);
 
 /**
+ * Retrieves the executable path of the given C++ source file.
+ *
+ * @param sourceFile - The path of the C++ source file.
+ * @returns The executable path of the C++ source file.
+ */
+export function getCppExecutablePath(sourceFile: string): string {
+  const executablePath = sourceFile.replace(path.extname(sourceFile), "");
+  return process.platform === "win32"
+    ? `${executablePath}.exe`
+    : executablePath;
+}
+
+/**
  * Compiles a C++ test file using Clang.
  *
  * @param testFile - The path of the C++ test file to compile.
@@ -16,7 +29,7 @@ export async function compileCppTest(
   testFile: string,
   outDir?: string,
 ): Promise<string> {
-  let outFile = testFile.replace(path.extname(testFile), "");
+  let outFile = getCppExecutablePath(testFile);
   if (outDir !== undefined) {
     await mkdir(outDir, { recursive: true });
     outFile = path.join(outDir, path.basename(outFile));


### PR DESCRIPTION
This pull request resolves #225 by introducing the following changes:
- Adding a new `getCppExecutablePath` function to specify the executable path from the given source file. This function will set the executable path with the `.exe` extension on the Windows platform.
- Utilizing the `getCppExecutablePath` function in the `compileCppTest` function, allowing it to compile the source file to an executable with the `.exe` extension on the Windows platform.
- Grouping tests for the `compileCppTest` function, separating them from the tests for the `getCppExecutablePath` function.