### PR TITLE
Execute C++ Test Executable Directly on Windows

### DIFF
--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -5,26 +5,13 @@ jest.unstable_mockModule("node:child_process", () => ({
   exec: jest.fn((_, callback: () => void) => callback()),
 }));
 
-it("should run a C++ test executable on Linux", async () => {
+it("should run a C++ test executable", async () => {
   const { exec } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
   jest.mocked(exec).mockClear();
-  Object.defineProperty(process, "platform", { value: "linux" });
 
   await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
   expect(jest.mocked(exec).mock.calls[0][0]).toBe("build/path/to/test");
-});
-
-it("should run a C++ test executable on Windows", async () => {
-  const { exec } = await import("node:child_process");
-  const { runCppTest } = await import("./run.js");
-
-  jest.mocked(exec).mockClear();
-  Object.defineProperty(process, "platform", { value: "win32" });
-
-  await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
-
-  expect(jest.mocked(exec).mock.calls[0][0]).toBe("start build/path/to/test");
 });

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -10,7 +10,5 @@ const execPromise = promisify(exec);
  * @returns A promise that resolves to nothing.
  */
 export async function runCppTest(testExec: string): Promise<void> {
-  await execPromise(
-    process.platform === "win32" ? `start ${testExec}` : testExec,
-  );
+  await execPromise(testExec);
 }


### PR DESCRIPTION
This pull request resolves #229 by directly executing the test executable on Windows, removing the separate implementation for Windows and other platforms.