### PR TITLE
Utilize `execFile` to Execute Processes

### DIFF
--- a/src/test/cpp/compile.ts
+++ b/src/test/cpp/compile.ts
@@ -1,9 +1,9 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { promisify } from "node:util";
 import path from "node:path";
 
-const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 /**
  * Retrieves the executable path of the given C++ source file.
@@ -34,6 +34,12 @@ export async function compileCppTest(
     await mkdir(outDir, { recursive: true });
     outFile = path.join(outDir, path.basename(outFile));
   }
-  await execPromise(`clang++ --std=c++20 -O2 ${testFile} -o ${outFile}`);
+  await execFilePromise("clang++", [
+    "--std=c++20",
+    "-O2",
+    testFile,
+    "-o",
+    outFile,
+  ]);
   return outFile;
 }

--- a/src/test/cpp/run.test.ts
+++ b/src/test/cpp/run.test.ts
@@ -2,16 +2,16 @@ import { jest } from "@jest/globals";
 import "jest-extended";
 
 jest.unstable_mockModule("node:child_process", () => ({
-  exec: jest.fn((_, callback: () => void) => callback()),
+  execFile: jest.fn((_, callback: () => void) => callback()),
 }));
 
 it("should run a C++ test executable", async () => {
-  const { exec } = await import("node:child_process");
+  const { execFile } = await import("node:child_process");
   const { runCppTest } = await import("./run.js");
 
-  jest.mocked(exec).mockClear();
+  jest.mocked(execFile).mockClear();
 
   await expect(runCppTest("build/path/to/test")).resolves.toBeUndefined();
 
-  expect(jest.mocked(exec).mock.calls[0][0]).toBe("build/path/to/test");
+  expect(jest.mocked(execFile).mock.calls[0][0]).toBe("build/path/to/test");
 });

--- a/src/test/cpp/run.ts
+++ b/src/test/cpp/run.ts
@@ -1,7 +1,7 @@
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
-const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
 
 /**
  * Runs a C++ test executable.
@@ -10,5 +10,5 @@ const execPromise = promisify(exec);
  * @returns A promise that resolves to nothing.
  */
 export async function runCppTest(testExec: string): Promise<void> {
-  await execPromise(testExec);
+  await execFilePromise(testExec);
 }


### PR DESCRIPTION
This pull request resolves #231 by utilizing the `execFile` function in the `runCppTest` and `compileCppTest` functions, optimizing the process execution.