### PR TITLE
Add Compile C Source File Function

### DIFF
--- a/src/compile/c.test.ts
+++ b/src/compile/c.test.ts
@@ -1,7 +1,10 @@
+import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { promisify } from "node:util";
-import { findGccExecutable } from "./c.js";
+import { compileCSource, findGccExecutable } from "./c.js";
+import { getExecutableFromSource } from "./utils.js";
 
 const execFilePromise = promisify(execFile);
 
@@ -11,4 +14,97 @@ it.concurrent("should find the GCC executable", async () => {
 
   const { stdout } = await execFilePromise(exeFile, ["--version"]);
   expect(stdout).toMatch("gcc");
+});
+
+describe("compile a C source file", () => {
+  const testDirs: ITempDirectory[] = [];
+  const getTestDir = async () => {
+    const testDir = await createTempDirectory();
+    testDirs.push(testDir);
+    return testDir;
+  };
+
+  describe("compile a valid C source file", () => {
+    const getSourcePath = async (testDir: ITempDirectory) => {
+      const sourceFile = path.join(testDir.path, "main.c");
+      await fs.writeFile(
+        sourceFile,
+        [
+          `#include <stdio.h>`,
+          ``,
+          `int main() {`,
+          `  printf("Hello world!\\n");`,
+          `  return 0;`,
+          `}`,
+        ].join("\n"),
+      );
+      return sourceFile;
+    };
+
+    it.concurrent(
+      "should compile a valid C source file",
+      async () => {
+        const testDir = await getTestDir();
+        const sourceFile = await getSourcePath(testDir);
+
+        const exeFile = await compileCSource(sourceFile);
+
+        expect(exeFile).toBe(
+          getExecutableFromSource(path.join(testDir.path, "main")),
+        );
+        await fs.access(exeFile, fs.constants.X_OK);
+      },
+      60000,
+    );
+
+    it.concurrent(
+      "should compile a valid C source file to a specified directory",
+      async () => {
+        const testDir = await getTestDir();
+        const sourceFile = await getSourcePath(testDir);
+
+        const exeFile = await compileCSource(
+          sourceFile,
+          path.join(testDir.path, "build"),
+        );
+
+        expect(exeFile).toBe(
+          getExecutableFromSource(path.join(testDir.path, "build", "main")),
+        );
+        await fs.access(exeFile, fs.constants.X_OK);
+      },
+      60000,
+    );
+  });
+
+  it.concurrent(
+    "should not compile an invalid C source file",
+    async () => {
+      const testDir = await getTestDir();
+
+      const sourceFile = path.join(testDir.path, "main.c");
+      await fs.writeFile(sourceFile, "int main() {");
+
+      await expect(compileCSource(sourceFile)).rejects.toThrow(
+        /Command failed:[^]*expected declaration or statement at end of input/,
+      );
+    },
+    60000,
+  );
+
+  it.concurrent(
+    "should not compile a non-existing C source file",
+    async () => {
+      const testDir = await getTestDir();
+      const sourceFile = path.join(testDir.path, "main.c");
+      await expect(compileCSource(sourceFile)).rejects.toThrow(
+        /Command failed:[^]*No such file or directory/,
+      );
+    },
+    60000,
+  );
+
+  afterAll(async () => {
+    await Promise.all(testDirs.map((testDir) => testDir.remove()));
+  });
 });

--- a/src/compile/c.ts
+++ b/src/compile/c.ts
@@ -1,4 +1,10 @@
-import { findExecutable } from "./utils.js";
+import { execFile } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { promisify } from "node:util";
+import path from "node:path";
+import { findExecutable, getExecutableFromSource } from "./utils.js";
+
+const execFilePromise = promisify(execFile);
 
 /**
  * Finds the GCC executable file.
@@ -7,4 +13,25 @@ import { findExecutable } from "./utils.js";
  */
 export async function findGccExecutable(): Promise<string> {
   return await findExecutable("gcc-13", "gcc");
+}
+
+/**
+ * Compiles a C source file using GCC.
+ *
+ * @param sourceFile - The path of the C source file to compile.
+ * @param outDir - An optional output directory for the compiled executable file.
+ * @returns A promise that resolves to the path of the compiled executable file.
+ */
+export async function compileCSource(
+  sourceFile: string,
+  outDir?: string,
+): Promise<string> {
+  const gccExeFile = await findGccExecutable();
+  let exeFile = getExecutableFromSource(sourceFile);
+  if (outDir !== undefined) {
+    await mkdir(outDir, { recursive: true });
+    exeFile = path.join(outDir, path.basename(exeFile));
+  }
+  await execFilePromise(gccExeFile, ["-O2", sourceFile, "-o", exeFile]);
+  return exeFile;
 }


### PR DESCRIPTION
This pull request resolves #310 by adding a new `compileCSource` function for compiling a C source file using GCC and updating the `compile/c.test.ts` test file accordingly.