### PR TITLE
Add Function to Find Clang++ Executable File

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "catched-error-message": "^0.0.1",
     "glob": "^10.4.1",
     "ora": "^8.0.1",
+    "which": "^4.0.0",
     "yaml": "^2.4.5",
     "yargs": "^17.7.2"
   },
@@ -42,6 +43,7 @@
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.9",
+    "@types/which": "^3.0.4",
     "@types/yargs": "^17.0.32",
     "create-temp-directory": "^2.4.0",
     "eslint": "^9.4.0",

--- a/src/compile/cpp.test.ts
+++ b/src/compile/cpp.test.ts
@@ -1,7 +1,7 @@
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { compileCppSource } from "./cpp.js";
+import { compileCppSource, findCppClangExecutable } from "./cpp.js";
 import { getExecutableFromSource } from "./utils.js";
 
 const testDirs: ITempDirectory[] = [];
@@ -10,6 +10,11 @@ const getTestDir = async () => {
   testDirs.push(testDir);
   return testDir;
 };
+
+it.concurrent("should find the C++ Clang executable", async () => {
+  const exeFile = await findCppClangExecutable();
+  await fs.access(exeFile, fs.constants.X_OK);
+});
 
 describe("compile a C++ source file", () => {
   describe("compile a valid C++ source file", () => {

--- a/src/compile/cpp.test.ts
+++ b/src/compile/cpp.test.ts
@@ -11,85 +11,87 @@ const getTestDir = async () => {
   return testDir;
 };
 
-describe("compile a valid C++ source file", () => {
-  const getSourcePath = async (testDir: ITempDirectory) => {
-    const sourceFile = path.join(testDir.path, "main.cpp");
-    await fs.writeFile(
-      sourceFile,
-      [
-        `#include <iostream>`,
-        ``,
-        `int main() {`,
-        `  std::cout << "Hello world!\\n";`,
-        `  return 0;`,
-        `}`,
-      ].join("\n"),
+describe("compile a C++ source file", () => {
+  describe("compile a valid C++ source file", () => {
+    const getSourcePath = async (testDir: ITempDirectory) => {
+      const sourceFile = path.join(testDir.path, "main.cpp");
+      await fs.writeFile(
+        sourceFile,
+        [
+          `#include <iostream>`,
+          ``,
+          `int main() {`,
+          `  std::cout << "Hello world!\\n";`,
+          `  return 0;`,
+          `}`,
+        ].join("\n"),
+      );
+      return sourceFile;
+    };
+
+    it.concurrent(
+      "should compile a valid C++ source file",
+      async () => {
+        const testDir = await getTestDir();
+        const sourceFile = await getSourcePath(testDir);
+
+        const exeFile = await compileCppSource(sourceFile);
+
+        expect(exeFile).toBe(
+          getExecutableFromSource(path.join(testDir.path, "main")),
+        );
+        await fs.access(exeFile, fs.constants.X_OK);
+      },
+      60000,
     );
-    return sourceFile;
-  };
+
+    it.concurrent(
+      "should compile a valid C++ source file to a specified directory",
+      async () => {
+        const testDir = await getTestDir();
+        const sourceFile = await getSourcePath(testDir);
+
+        const exeFile = await compileCppSource(
+          sourceFile,
+          path.join(testDir.path, "build"),
+        );
+
+        expect(exeFile).toBe(
+          getExecutableFromSource(path.join(testDir.path, "build", "main")),
+        );
+        await fs.access(exeFile, fs.constants.X_OK);
+      },
+      60000,
+    );
+  });
 
   it.concurrent(
-    "should compile a valid C++ source file",
+    "should not compile an invalid C++ source file",
     async () => {
       const testDir = await getTestDir();
-      const sourceFile = await getSourcePath(testDir);
 
-      const exeFile = await compileCppSource(sourceFile);
+      const sourceFile = path.join(testDir.path, "main.cpp");
+      await fs.writeFile(sourceFile, "int main() {");
 
-      expect(exeFile).toBe(
-        getExecutableFromSource(path.join(testDir.path, "main")),
+      await expect(compileCppSource(sourceFile)).rejects.toThrow(
+        /Command failed:[^]*1 error generated/,
       );
-      await fs.access(exeFile, fs.constants.X_OK);
     },
     60000,
   );
 
   it.concurrent(
-    "should compile a valid C++ source file to a specified directory",
+    "should not compile a non-existing C++ source file",
     async () => {
       const testDir = await getTestDir();
-      const sourceFile = await getSourcePath(testDir);
-
-      const exeFile = await compileCppSource(
-        sourceFile,
-        path.join(testDir.path, "build"),
+      const sourceFile = path.join(testDir.path, "main.cpp");
+      await expect(compileCppSource(sourceFile)).rejects.toThrow(
+        /Command failed:[^]*no such file or directory/,
       );
-
-      expect(exeFile).toBe(
-        getExecutableFromSource(path.join(testDir.path, "build", "main")),
-      );
-      await fs.access(exeFile, fs.constants.X_OK);
     },
     60000,
   );
 });
-
-it.concurrent(
-  "should not compile an invalid C++ source file",
-  async () => {
-    const testDir = await getTestDir();
-
-    const sourceFile = path.join(testDir.path, "main.cpp");
-    await fs.writeFile(sourceFile, "int main() {");
-
-    await expect(compileCppSource(sourceFile)).rejects.toThrow(
-      /Command failed:[^]*1 error generated/,
-    );
-  },
-  60000,
-);
-
-it.concurrent(
-  "should not compile a non-existing C++ source file",
-  async () => {
-    const testDir = await getTestDir();
-    const sourceFile = path.join(testDir.path, "main.cpp");
-    await expect(compileCppSource(sourceFile)).rejects.toThrow(
-      /Command failed:[^]*no such file or directory/,
-    );
-  },
-  60000,
-);
 
 afterAll(async () => {
   await Promise.all(testDirs.map((testDir) => testDir.remove()));

--- a/src/compile/cpp.ts
+++ b/src/compile/cpp.ts
@@ -2,9 +2,19 @@ import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { promisify } from "node:util";
 import path from "node:path";
+import which from "which";
 import { getExecutableFromSource } from "./utils.js";
 
 const execFilePromise = promisify(execFile);
+
+/**
+ * Finds the C++ Clang executable file.
+ *
+ * @returns A promise that resolves to the path of the C++ Clang executable file.
+ */
+export async function findCppClangExecutable(): Promise<string> {
+  return await which("clang++");
+}
 
 /**
  * Compiles a C++ source file using Clang.
@@ -17,12 +27,13 @@ export async function compileCppSource(
   sourceFile: string,
   outDir?: string,
 ): Promise<string> {
+  const cppClangExeFile = await findCppClangExecutable();
   let exeFile = getExecutableFromSource(sourceFile);
   if (outDir !== undefined) {
     await mkdir(outDir, { recursive: true });
     exeFile = path.join(outDir, path.basename(exeFile));
   }
-  await execFilePromise("clang++", [
+  await execFilePromise(cppClangExeFile, [
     "--std=c++20",
     "-O2",
     sourceFile,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/which@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@types/which@npm:3.0.4"
+  checksum: 10c0/036e4cb243ebfd5cf4893be2ab3b9a60a22368811c1f1c78fb8fc70cadc274024282d04b8d7c0948268372600003252d84e2d3a5e064014a543a5da235c5989d
+  languageName: node
+  linkType: hard
+
 "@types/yargs-parser@npm:*":
   version: 21.0.3
   resolution: "@types/yargs-parser@npm:21.0.3"
@@ -3450,6 +3457,7 @@ __metadata:
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.14.9"
+    "@types/which": "npm:^3.0.4"
     "@types/yargs": "npm:^17.0.32"
     catched-error-message: "npm:^0.0.1"
     create-temp-directory: "npm:^2.4.0"
@@ -3463,6 +3471,7 @@ __metadata:
     tsx: "npm:^4.16.2"
     typescript: "npm:^5.5.3"
     typescript-eslint: "npm:^7.13.0"
+    which: "npm:^4.0.0"
     yaml: "npm:^2.4.5"
     yargs: "npm:^17.7.2"
   bin:


### PR DESCRIPTION
This pull request resolves #312 by adding a new `findCppClangExecutable` function for finding the full path of the `clang++` executable file. It also modifies the `compile/cpp.test.ts` file to organize the "compile a C+ source file" test in one block.