### PR TITLE
Add Function to Find GCC Executable File

### DIFF
--- a/src/compile/c.test.ts
+++ b/src/compile/c.test.ts
@@ -1,7 +1,14 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
+import { promisify } from "node:util";
 import { findGccExecutable } from "./c.js";
+
+const execFilePromise = promisify(execFile);
 
 it.concurrent("should find the GCC executable", async () => {
   const exeFile = await findGccExecutable();
   await fs.access(exeFile, fs.constants.X_OK);
+
+  const { stdout } = await execFilePromise(exeFile, ["--version"]);
+  expect(stdout).toMatch("gcc");
 });

--- a/src/compile/c.test.ts
+++ b/src/compile/c.test.ts
@@ -1,0 +1,7 @@
+import fs from "node:fs/promises";
+import { findGccExecutable } from "./c.js";
+
+it.concurrent("should find the GCC executable", async () => {
+  const exeFile = await findGccExecutable();
+  await fs.access(exeFile, fs.constants.X_OK);
+});

--- a/src/compile/c.ts
+++ b/src/compile/c.ts
@@ -1,0 +1,10 @@
+import { findExecutable } from "./utils.js";
+
+/**
+ * Finds the GCC executable file.
+ *
+ * @returns A promise that resolves to the path of the GCC executable file.
+ */
+export async function findGccExecutable(): Promise<string> {
+  return await findExecutable("gcc-13", "gcc");
+}


### PR DESCRIPTION
This pull request resolves #314 by adding a new `findGccExecutable` function to get the path of the GCC executable file.