### PR TITLE
Fully Utilize Run Executable Function

### DIFF
--- a/src/compile/c.test.ts
+++ b/src/compile/c.test.ts
@@ -1,19 +1,16 @@
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
-import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { promisify } from "node:util";
+import { runExecutable } from "../run.js";
 import { compileCSource, findGccExecutable } from "./c.js";
 import { getExecutableFromSource } from "./utils.js";
-
-const execFilePromise = promisify(execFile);
 
 it.concurrent("should find the GCC executable", async () => {
   const exeFile = await findGccExecutable();
   await fs.access(exeFile, fs.constants.X_OK);
 
-  const { stdout } = await execFilePromise(exeFile, ["--version"]);
-  expect(stdout).toMatch("gcc");
+  const output = await runExecutable(exeFile, ["--version"]);
+  expect(output).toMatch(/gcc/);
 });
 
 describe("compile a C source file", () => {

--- a/src/compile/c.ts
+++ b/src/compile/c.ts
@@ -1,10 +1,7 @@
-import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
-import { promisify } from "node:util";
 import path from "node:path";
+import { runExecutable } from "../run.js";
 import { findExecutable, getExecutableFromSource } from "./utils.js";
-
-const execFilePromise = promisify(execFile);
 
 /**
  * Finds the GCC executable file.
@@ -32,6 +29,6 @@ export async function compileCSource(
     await mkdir(outDir, { recursive: true });
     exeFile = path.join(outDir, path.basename(exeFile));
   }
-  await execFilePromise(gccExeFile, ["-O2", sourceFile, "-o", exeFile]);
+  await runExecutable(gccExeFile, ["-O2", sourceFile, "-o", exeFile]);
   return exeFile;
 }

--- a/src/compile/cpp.ts
+++ b/src/compile/cpp.ts
@@ -1,10 +1,7 @@
-import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
-import { promisify } from "node:util";
 import path from "node:path";
+import { runExecutable } from "../run.js";
 import { findExecutable, getExecutableFromSource } from "./utils.js";
-
-const execFilePromise = promisify(execFile);
 
 /**
  * Finds the C++ Clang executable file.
@@ -32,7 +29,7 @@ export async function compileCppSource(
     await mkdir(outDir, { recursive: true });
     exeFile = path.join(outDir, path.basename(exeFile));
   }
-  await execFilePromise(cppClangExeFile, [
+  await runExecutable(cppClangExeFile, [
     "--std=c++20",
     "-O2",
     sourceFile,

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -18,11 +18,23 @@ it.concurrent(
     const testDir = await getTestDir();
 
     const sourceFile = path.join(testDir.path, "main.cpp");
-    await fs.writeFile(sourceFile, "int main() { return 0; }\n");
+    await fs.writeFile(
+      sourceFile,
+      [
+        `#include <iostream>`,
+        ``,
+        `int main() {`,
+        `  std::cout << "some output\\n";`,
+        `  return 0;`,
+        `}`,
+        ``,
+      ].join("\n"),
+    );
 
     const exeFile = await compileCppSource(sourceFile);
 
-    await runExecutable(exeFile);
+    const output = await runExecutable(exeFile);
+    expect(output).toMatch(/some output/);
   },
   60000,
 );
@@ -36,13 +48,15 @@ it.concurrent(
     await fs.writeFile(
       sourceFile,
       [
-        `#include <cassert>`,
-        `#include <cstring>`,
+        `#include <iostream>`,
         ``,
         `int main(int argc, char** argv) {`,
-        `  assert(argc == 3);`,
-        `  assert(strcmp(argv[1], "foo") == 0);`,
-        `  assert(strcmp(argv[2], "bar") == 0);`,
+        `  if (argc < 2) return 1;`,
+        `  std::cout << argv[1];`,
+        `  for (int i{2}; i < argc; ++i) {`,
+        `    std::cout << " " << argv[i];`,
+        `  }`,
+        `  std::cout << "\\n";`,
         `  return 0;`,
         `}`,
         ``,
@@ -51,7 +65,8 @@ it.concurrent(
 
     const exeFile = await compileCppSource(sourceFile);
 
-    await runExecutable(exeFile, ["foo", "bar"]);
+    const output = await runExecutable(exeFile, ["foo", "bar"]);
+    expect(output).toMatch(/foo bar/);
   },
   60000,
 );

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -28,6 +28,35 @@ it.concurrent(
 );
 
 it.concurrent(
+  "should run an executable file with arguments",
+  async () => {
+    const testDir = await getTestDir();
+
+    const sourceFile = path.join(testDir.path, "main.cpp");
+    await fs.writeFile(
+      sourceFile,
+      [
+        `#include <cassert>`,
+        `#include <cstring>`,
+        ``,
+        `int main(int argc, char** argv) {`,
+        `  assert(argc == 3);`,
+        `  assert(strcmp(argv[1], "foo") == 0);`,
+        `  assert(strcmp(argv[2], "bar") == 0);`,
+        `  return 0;`,
+        `}`,
+        ``,
+      ].join("\n"),
+    );
+
+    const exeFile = await compileCppSource(sourceFile);
+
+    await runExecutable(exeFile, ["foo", "bar"]);
+  },
+  60000,
+);
+
+it.concurrent(
   "should run a failing executable file",
   async () => {
     const testDir = await getTestDir();

--- a/src/run.ts
+++ b/src/run.ts
@@ -7,8 +7,12 @@ const execFilePromise = promisify(execFile);
  * Runs an executable file.
  *
  * @param exeFile - The path of the executable file to run.
+ * @param args - The arguments to pass to the executable file.
  * @returns A promise that resolves when the executable file has finished running.
  */
-export async function runExecutable(exeFile: string): Promise<void> {
-  await execFilePromise(exeFile);
+export async function runExecutable(
+  exeFile: string,
+  args?: string[],
+): Promise<void> {
+  await execFilePromise(exeFile, args);
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,11 +8,12 @@ const execFilePromise = promisify(execFile);
  *
  * @param exeFile - The path of the executable file to run.
  * @param args - The arguments to pass to the executable file.
- * @returns A promise that resolves when the executable file has finished running.
+ * @returns A promise that resolves to the output of the executable run.
  */
 export async function runExecutable(
   exeFile: string,
   args?: string[],
-): Promise<void> {
-  await execFilePromise(exeFile, args);
+): Promise<string> {
+  const { stdout } = await execFilePromise(exeFile, args);
+  return stdout;
 }


### PR DESCRIPTION
This pull request resolves #316 by modifying the `runExecutable` function to optionally pass arguments when running an executable and return the output of the executable after the process is done. It also updates the `runExecutable` function for use in all other functions, replacing the `fs.exeFile` function.