### PR TITLE
Add Function to Find Executable File With Multiple Alias

### DIFF
--- a/src/compile/cpp.ts
+++ b/src/compile/cpp.ts
@@ -2,8 +2,7 @@ import { execFile } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import { promisify } from "node:util";
 import path from "node:path";
-import which from "which";
-import { getExecutableFromSource } from "./utils.js";
+import { findExecutable, getExecutableFromSource } from "./utils.js";
 
 const execFilePromise = promisify(execFile);
 
@@ -13,7 +12,7 @@ const execFilePromise = promisify(execFile);
  * @returns A promise that resolves to the path of the C++ Clang executable file.
  */
 export async function findCppClangExecutable(): Promise<string> {
-  return await which("clang++");
+  return await findExecutable("clang++");
 }
 
 /**

--- a/src/compile/utils.test.ts
+++ b/src/compile/utils.test.ts
@@ -1,36 +1,38 @@
 import path from "node:path";
 import { getExecutableFromSource } from "./utils.js";
 
-let originalPlatform: string | undefined = undefined;
+describe("retrieve an executable file path", () => {
+  let originalPlatform: string | undefined = undefined;
 
-const mockPlatform = (newPlatform: string) => {
-  if (originalPlatform === undefined) originalPlatform = process.platform;
-  Object.defineProperty(process, "platform", { value: newPlatform });
-};
+  const mockPlatform = (newPlatform: string) => {
+    if (originalPlatform === undefined) originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: newPlatform });
+  };
 
-const restorePlatform = () => {
-  if (originalPlatform === undefined) return;
-  Object.defineProperty(process, "platform", { value: originalPlatform });
-};
+  const restorePlatform = () => {
+    if (originalPlatform === undefined) return;
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+  };
 
-it.concurrent(
-  "should retrieve an executable file path on Windows platform",
-  () => {
-    mockPlatform("win32");
-    expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
-      path.join("path", "to", "main.exe"),
-    );
-  },
-);
+  it.concurrent(
+    "should retrieve an executable file path on Windows platform",
+    () => {
+      mockPlatform("win32");
+      expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
+        path.join("path", "to", "main.exe"),
+      );
+    },
+  );
 
-it.concurrent(
-  "should retrieve an executable file path on non-Windows platform",
-  () => {
-    mockPlatform("non-win32");
-    expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
-      path.join("path", "to", "main"),
-    );
-  },
-);
+  it.concurrent(
+    "should retrieve an executable file path on non-Windows platform",
+    () => {
+      mockPlatform("non-win32");
+      expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
+        path.join("path", "to", "main"),
+      );
+    },
+  );
 
-afterAll(() => restorePlatform());
+  afterAll(() => restorePlatform());
+});

--- a/src/compile/utils.test.ts
+++ b/src/compile/utils.test.ts
@@ -43,36 +43,28 @@ describe("find an executable file", () => {
 
 describe("retrieve an executable file path", () => {
   let originalPlatform: string | undefined = undefined;
-
   const mockPlatform = (newPlatform: string) => {
     if (originalPlatform === undefined) originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: newPlatform });
   };
 
-  const restorePlatform = () => {
-    if (originalPlatform === undefined) return;
-    Object.defineProperty(process, "platform", { value: originalPlatform });
-  };
+  it("should retrieve an executable file path on Windows platform", () => {
+    mockPlatform("win32");
+    expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
+      path.join("path", "to", "main.exe"),
+    );
+  });
 
-  it.concurrent(
-    "should retrieve an executable file path on Windows platform",
-    () => {
-      mockPlatform("win32");
-      expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
-        path.join("path", "to", "main.exe"),
-      );
-    },
-  );
+  it("should retrieve an executable file path on non-Windows platform", () => {
+    mockPlatform("non-win32");
+    expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
+      path.join("path", "to", "main"),
+    );
+  });
 
-  it.concurrent(
-    "should retrieve an executable file path on non-Windows platform",
-    () => {
-      mockPlatform("non-win32");
-      expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
-        path.join("path", "to", "main"),
-      );
-    },
-  );
-
-  afterAll(() => restorePlatform());
+  afterEach(() => {
+    if (originalPlatform !== undefined) {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
 });

--- a/src/compile/utils.test.ts
+++ b/src/compile/utils.test.ts
@@ -1,5 +1,40 @@
+import { createTempDirectory, ITempDirectory } from "create-temp-directory";
+import fs from "node:fs/promises";
 import path from "node:path";
-import { getExecutableFromSource } from "./utils.js";
+import { findExecutable, getExecutableFromSource } from "./utils.js";
+
+describe("find an executable file", () => {
+  let testDir: ITempDirectory;
+  let originalPathEnv: string | undefined;
+
+  beforeAll(async () => {
+    testDir = await createTempDirectory();
+
+    let exeFilePath = path.join(testDir.path, "some-exe");
+    if (process.platform == "win32") exeFilePath += ".exe";
+
+    await (await fs.open(exeFilePath, "w", 0o777)).close();
+
+    originalPathEnv = process.env.PATH;
+    process.env.PATH = testDir.path;
+  });
+
+  it("should find an existing executable file", async () => {
+    const exeFile = await findExecutable("some-exe");
+    await fs.access(exeFile, fs.constants.X_OK);
+  });
+
+  it("should not find a non-existing executable file", async () => {
+    await expect(findExecutable("non-existing-exe")).rejects.toThrow(
+      "not found: non-existing-exe",
+    );
+  });
+
+  afterAll(async () => {
+    testDir.remove();
+    process.env.PATH = originalPathEnv;
+  });
+});
 
 describe("retrieve an executable file path", () => {
   let originalPlatform: string | undefined = undefined;

--- a/src/compile/utils.test.ts
+++ b/src/compile/utils.test.ts
@@ -24,6 +24,11 @@ describe("find an executable file", () => {
     await fs.access(exeFile, fs.constants.X_OK);
   });
 
+  it("should find an existing executable file using an alternative name", async () => {
+    const exeFile = await findExecutable("other-exe", "some-exe");
+    await fs.access(exeFile, fs.constants.X_OK);
+  });
+
   it("should not find a non-existing executable file", async () => {
     await expect(findExecutable("non-existing-exe")).rejects.toThrow(
       "not found: non-existing-exe",

--- a/src/compile/utils.ts
+++ b/src/compile/utils.ts
@@ -5,10 +5,21 @@ import which from "which";
  * Finds the path of an executable file with the given name.
  *
  * @param name - The name of the executable file to find.
+ * @param alternativeNames - List of alternative names for the executable file.
  * @returns A promise that resolves to the path of the executable file.
  */
-export async function findExecutable(name: string): Promise<string> {
-  return which(name);
+export async function findExecutable(
+  name: string,
+  ...alternativeNames: string[]
+): Promise<string> {
+  const names = [name, ...alternativeNames];
+
+  for (const name of names) {
+    const exeFile = await which(name, { nothrow: true });
+    if (exeFile !== null) return exeFile;
+  }
+
+  throw new Error(`not found: ${names.join(", ")}`);
 }
 
 /**

--- a/src/compile/utils.ts
+++ b/src/compile/utils.ts
@@ -1,4 +1,15 @@
 import path from "node:path";
+import which from "which";
+
+/**
+ * Finds the path of an executable file with the given name.
+ *
+ * @param name - The name of the executable file to find.
+ * @returns A promise that resolves to the path of the executable file.
+ */
+export async function findExecutable(name: string): Promise<string> {
+  return which(name);
+}
 
 /**
  * Retrieves the executable file path for the given C++ source file.


### PR DESCRIPTION
This pull request resolves #318 by introducing a new `findExecutable` function to find the path of an executable file with the specified name. It utilizes the `findExecutable` function within the `findCppClangExecutable` function, replacing the `which` function. Additionally, it adjusts the tests in the `compile/utils.test.ts` file accordingly.