### PR TITLE
Rename YAML Schema to Raw Test Schema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { testSolutions } from "./test/index.js";
-export { readYamlSchema, Schema } from "./test/schema.js";
+export { readYamlSchema, RawTestSchema } from "./test/schema.js";
 export { searchSolutions } from "./search.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { testSolutions } from "./test/index.js";
-export { readYamlSchema, RawTestSchema } from "./test/schema.js";
+export { RawTestSchema, readRawTestSchema } from "./test/schema.js";
 export { searchSolutions } from "./search.js";

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource } from "../../../compile/cpp.js";
 import { runExecutable } from "../../../run.js";
-import { Schema } from "../../schema.js";
+import { RawTestSchema } from "../../schema.js";
 import { generateCppTest } from "./index.js";
 
 const testDirs: ITempDirectory[] = [];
@@ -16,7 +16,7 @@ const getTestDir = async () => {
 it.concurrent(
   "should generate a C++ test file",
   async () => {
-    const schema: Schema = {
+    const schema: RawTestSchema = {
       cpp: {
         function: {
           name: "sum",

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,19 +1,19 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { Schema } from "../../schema.js";
+import { RawTestSchema } from "../../schema.js";
 import { generateCppMainCode } from "./main.js";
 import { generateCppUtilityCode } from "./utility.js";
 
 /**
  * Generates a C++ test file from a test schema.
  *
- * @param schema - The test schema.
+ * @param schema - The raw test schema.
  * @param solutionFile - The path of the C++ solution file.
  * @param outFile - The path of the C++ test file output.
  * @returns A promise that resolves to nothing.
  */
 export async function generateCppTest(
-  schema: Schema,
+  schema: RawTestSchema,
   solutionFile: string,
   outFile: string,
 ): Promise<void> {

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,13 +1,13 @@
-import { Schema } from "../../schema.js";
+import { RawTestSchema } from "../../schema.js";
 import { formatCpp } from "./format.js";
 
 /**
  * Generates C++ main function code from a test schema.
  *
- * @param schema - The test schema.
+ * @param schema - The raw test schema.
  * @returns An object containing the generated C++ code and a set of required headers.
  */
-export function generateCppMainCode(schema: Schema): {
+export function generateCppMainCode(schema: RawTestSchema): {
   code: string;
   headers: Set<string>;
 } {

--- a/src/test/cpp/generate/utility.ts
+++ b/src/test/cpp/generate/utility.ts
@@ -1,4 +1,4 @@
-import { Schema } from "../../schema.js";
+import { RawTestSchema } from "../../schema.js";
 
 export const cppVectorOstreamOperatorCode = [
   `template <typename T>`,
@@ -18,10 +18,10 @@ export const cppVectorOstreamOperatorCode = [
 /**
  * Generates C++ utility functions code from a test schema.
  *
- * @param schema - The test schema.
+ * @param schema - The raw test schema.
  * @returns The generated C++ utility functions code.
  */
-export function generateCppUtilityCode(schema: Schema): string {
+export function generateCppUtilityCode(schema: RawTestSchema): string {
   if (schema.cpp.output.match(/^std::vector<.*>$/)) {
     return cppVectorOstreamOperatorCode;
   }

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -1,6 +1,6 @@
 import { jest } from "@jest/globals";
 import path from "node:path";
-import { Schema } from "../schema.js";
+import { RawTestSchema } from "../schema.js";
 import "jest-extended";
 
 jest.unstable_mockModule("../../compile/cpp.js", () => ({
@@ -26,7 +26,7 @@ it("should test a C++ solution", async () => {
   const { generateCppTest } = await import("./generate/index.js");
   const { testCppSolution } = await import("./index.js");
 
-  const schema: Schema = {
+  const schema: RawTestSchema = {
     cpp: {
       function: {
         name: "sum",

--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -12,7 +12,7 @@ jest.unstable_mockModule("../../run.js", () => ({
 }));
 
 jest.unstable_mockModule("../schema.js", () => ({
-  readYamlSchema: jest.fn(),
+  readRawTestSchema: jest.fn(),
 }));
 
 jest.unstable_mockModule("./generate.js", () => ({
@@ -22,7 +22,7 @@ jest.unstable_mockModule("./generate.js", () => ({
 it("should test a C++ solution", async () => {
   const { compileCppSource } = await import("../../compile/cpp.js");
   const { runExecutable } = await import("../../run.js");
-  const { readYamlSchema } = await import("../schema.js");
+  const { readRawTestSchema } = await import("../schema.js");
   const { generateCppTest } = await import("./generate/index.js");
   const { testCppSolution } = await import("./index.js");
 
@@ -58,7 +58,7 @@ it("should test a C++ solution", async () => {
     ],
   };
 
-  jest.mocked(readYamlSchema).mockResolvedValue(schema);
+  jest.mocked(readRawTestSchema).mockResolvedValue(schema);
   jest.mocked(compileCppSource).mockImplementation(async (testFile, outDir) => {
     const outFile = testFile.replace(path.extname(testFile), "");
     return outDir !== undefined
@@ -70,11 +70,11 @@ it("should test a C++ solution", async () => {
     testCppSolution(path.join("path", "to", "solution.cpp")),
   ).resolves.toBeUndefined();
 
-  expect(readYamlSchema).toHaveBeenCalledExactlyOnceWith(
+  expect(readRawTestSchema).toHaveBeenCalledExactlyOnceWith(
     path.join("path", "to", "test.yaml"),
   );
 
-  expect(generateCppTest).toHaveBeenCalledAfter(jest.mocked(readYamlSchema));
+  expect(generateCppTest).toHaveBeenCalledAfter(jest.mocked(readRawTestSchema));
   expect(generateCppTest).toHaveBeenCalledExactlyOnceWith(
     schema,
     path.join("path", "to", "solution.cpp"),

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { compileCppSource } from "../../compile/cpp.js";
 import { runExecutable } from "../../run.js";
-import { readYamlSchema } from "../schema.js";
+import { readRawTestSchema } from "../schema.js";
 import { generateCppTest } from "./generate/index.js";
 
 /**
@@ -15,7 +15,7 @@ import { generateCppTest } from "./generate/index.js";
  */
 export async function testCppSolution(solutionFile: string): Promise<void> {
   const schemaFile = path.join(path.dirname(solutionFile), "test.yaml");
-  const schema = await readYamlSchema(schemaFile);
+  const schema = await readRawTestSchema(schemaFile);
 
   const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
   await generateCppTest(schema, solutionFile, testFile);

--- a/src/test/schema.test.ts
+++ b/src/test/schema.test.ts
@@ -1,7 +1,7 @@
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { readYamlSchema } from "./schema.js";
+import { readRawTestSchema } from "./schema.js";
 
 const testDirs: ITempDirectory[] = [];
 const getTestDir = async () => {
@@ -11,7 +11,7 @@ const getTestDir = async () => {
 };
 
 it.concurrent(
-  "should read a YAML schema file",
+  "should read a raw test schema file",
   async () => {
     const testDir = await getTestDir();
 
@@ -44,7 +44,7 @@ it.concurrent(
       ].join("\n"),
     );
 
-    await expect(readYamlSchema(schemaPath)).resolves.toEqual({
+    await expect(readRawTestSchema(schemaPath)).resolves.toEqual({
       cpp: {
         function: {
           name: "sum",

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import YAML from "yaml";
 
-export interface Schema {
+export interface RawTestSchema {
   cpp: {
     function: {
       name: string;
@@ -23,7 +23,9 @@ export interface Schema {
  * @param schemaFile - The path of the YAML schema file.
  * @returns A promise that resolves to the parsed test schema.
  */
-export async function readYamlSchema(schemaFile: string): Promise<Schema> {
+export async function readYamlSchema(
+  schemaFile: string,
+): Promise<RawTestSchema> {
   const data = await readFile(schemaFile, "utf-8");
   return YAML.parse(data);
 }

--- a/src/test/schema.ts
+++ b/src/test/schema.ts
@@ -18,14 +18,12 @@ export interface RawTestSchema {
 }
 
 /**
- * Reads a test schema from a YAML file.
+ * Reads a raw test schema from a file.
  *
- * @param schemaFile - The path of the YAML schema file.
- * @returns A promise that resolves to the parsed test schema.
+ * @param file - The path of the raw test schema file.
+ * @returns A promise that resolves to the parsed raw test schema.
  */
-export async function readYamlSchema(
-  schemaFile: string,
-): Promise<RawTestSchema> {
-  const data = await readFile(schemaFile, "utf-8");
+export async function readRawTestSchema(file: string): Promise<RawTestSchema> {
+  const data = await readFile(file, "utf-8");
   return YAML.parse(data);
 }


### PR DESCRIPTION
This pull request resolves #331 by renaming the `Schema` interface to `RawTestSchema` and renaming the `readYamlSchema` function to `readRawTestSchema`.