### PR TITLE
Retry Compilation Tests on Timeout

### DIFF
--- a/src/compile/cpp.test.ts
+++ b/src/compile/cpp.test.ts
@@ -1,8 +1,11 @@
+import { jest } from "@jest/globals";
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource, findCppClangExecutable } from "./cpp.js";
 import { getExecutableFromSource } from "./utils.js";
+
+jest.retryTimes(10);
 
 const testDirs: ITempDirectory[] = [];
 const getTestDir = async () => {

--- a/src/run.test.ts
+++ b/src/run.test.ts
@@ -1,9 +1,12 @@
+import { jest } from "@jest/globals";
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource } from "./compile/cpp.js";
 import { getExecutableFromSource } from "./compile/utils.js";
 import { runExecutable } from "./run.js";
+
+jest.retryTimes(10);
 
 const testDirs: ITempDirectory[] = [];
 const getTestDir = async () => {

--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -5,6 +6,8 @@ import { compileCppSource } from "../../../compile/cpp.js";
 import { runExecutable } from "../../../run.js";
 import { RawTestSchema } from "../../schema.js";
 import { generateCppTest } from "./index.js";
+
+jest.retryTimes(10);
 
 const testDirs: ITempDirectory[] = [];
 const getTestDir = async () => {


### PR DESCRIPTION
This pull request resolves #334 by using the [`jest.retryTimes`](https://jestjs.io/docs/jest-object#jestretrytimesnumretries-options) function to retry the compilation tests when they timeout.