### PR TITLE
Change Build Directory to be Relative to the Solution File

### DIFF
--- a/src/test/cpp/index.test.ts
+++ b/src/test/cpp/index.test.ts
@@ -78,16 +78,16 @@ it("should test a C++ solution", async () => {
   expect(generateCppTest).toHaveBeenCalledExactlyOnceWith(
     schema,
     path.join("path", "to", "solution.cpp"),
-    path.join("build", "path", "to", "test.cpp"),
+    path.join("path", "to", "build", "test.cpp"),
   );
 
   expect(compileCppSource).toHaveBeenCalledAfter(jest.mocked(generateCppTest));
   expect(compileCppSource).toHaveBeenCalledExactlyOnceWith(
-    path.join("build", "path", "to", "test.cpp"),
+    path.join("path", "to", "build", "test.cpp"),
   );
 
   expect(runExecutable).toHaveBeenCalledAfter(jest.mocked(compileCppSource));
   expect(runExecutable).toHaveBeenCalledExactlyOnceWith(
-    path.join("build", "path", "to", "test"),
+    path.join("path", "to", "build", "test"),
   );
 });

--- a/src/test/cpp/index.ts
+++ b/src/test/cpp/index.ts
@@ -17,7 +17,7 @@ export async function testCppSolution(solutionFile: string): Promise<void> {
   const schemaFile = path.join(path.dirname(solutionFile), "test.yaml");
   const schema = await readRawTestSchema(schemaFile);
 
-  const testFile = path.join("build", path.dirname(solutionFile), "test.cpp");
+  const testFile = path.join(path.dirname(solutionFile), "build", "test.cpp");
   await generateCppTest(schema, solutionFile, testFile);
 
   const testExec = await compileCppSource(testFile);


### PR DESCRIPTION
This pull request resolves #338 by changing the `testCppSolution` function to place the build directory in the same directory as the C++ solution file.