### PR TITLE
Modify Some Sample Problems to Receive Inputs as References

### DIFF
--- a/sample/problems/appendIntegersArrays/solution.cpp
+++ b/sample/problems/appendIntegersArrays/solution.cpp
@@ -2,7 +2,7 @@
 
 class Solution {
  public:
-  std::vector<int> appendIntegersArrays(std::vector<int> nums1, std::vector<int> nums2) {
+  std::vector<int> appendIntegersArrays(std::vector<int>& nums1, std::vector<int>& nums2) {
     nums1.insert(nums1.end(), nums2.begin(), nums2.end());
     return nums1;
   }

--- a/sample/problems/appendStringsArrays/solution.cpp
+++ b/sample/problems/appendStringsArrays/solution.cpp
@@ -3,7 +3,7 @@
 
 class Solution {
  public:
-  std::vector<std::string> appendStringsArrays(std::vector<std::string> strs1, std::vector<std::string> strs2) {
+  std::vector<std::string> appendStringsArrays(std::vector<std::string>& strs1, std::vector<std::string>& strs2) {
     strs1.insert(strs1.end(), strs2.begin(), strs2.end());
     return strs1;
   }


### PR DESCRIPTION
This pull request resolves #341 by modifying the `appendIntegersArrays` and `appendStringsArrays` sample problems to receive inputs as references, particularly for the `std::vector` inputs.