### PR TITLE
Retry C Compilation Tests on Timeout

### DIFF
--- a/src/compile/c.test.ts
+++ b/src/compile/c.test.ts
@@ -1,9 +1,12 @@
+import { jest } from "@jest/globals";
 import { createTempDirectory, ITempDirectory } from "create-temp-directory";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { runExecutable } from "../run.js";
 import { compileCSource, findGccExecutable } from "./c.js";
 import { getExecutableFromSource } from "./utils.js";
+
+jest.retryTimes(10);
 
 it.concurrent("should find the GCC executable", async () => {
   const exeFile = await findGccExecutable();


### PR DESCRIPTION
This pull request modifies the C compilation tests in the `src/compile/c.test.ts` file to support up to 10 retries if they fail. This change should actually be implemented in #335.