### PR TITLE
Add C++ Headers Generator Class

### DIFF
--- a/src/test/cpp/generate/headers.test.ts
+++ b/src/test/cpp/generate/headers.test.ts
@@ -1,0 +1,74 @@
+import { jest } from "@jest/globals";
+import { createTempDirectory, ITempDirectory } from "create-temp-directory";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { compileCppSource } from "../../../compile/cpp.js";
+import { runExecutable } from "../../../run.js";
+import { CppHeaders } from "./headers.js";
+
+jest.retryTimes(10);
+
+describe("generate C++ code for including headers", () => {
+  it.concurrent("should generate C++ code for including headers", () => {
+    const headers = new CppHeaders(["iostream", "vector"]);
+    expect(headers.generateCode()).toEqual(
+      `#include <iostream>\n#include <vector>`,
+    );
+  });
+
+  it.concurrent(
+    "should generate C++ code for including headers after inserting a new header",
+    () => {
+      const headers = new CppHeaders(["iostream", "vector"]);
+      headers.add("string");
+
+      expect(headers.generateCode()).toEqual(
+        `#include <iostream>\n#include <string>\n#include <vector>`,
+      );
+    },
+  );
+
+  describe("compile the generated C++ code for including headers", () => {
+    const testDirs: ITempDirectory[] = [];
+    const getTestDir = async () => {
+      const testDir = await createTempDirectory();
+      testDirs.push(testDir);
+      return testDir;
+    };
+
+    it.concurrent(
+      "should compile the generated C++ code for including headers",
+      async () => {
+        const testDir = await getTestDir();
+
+        const headers = new CppHeaders(["iostream", "vector"]);
+
+        const mainFile = path.join(testDir.path, "main.cpp");
+        await fs.writeFile(
+          mainFile,
+          [
+            headers.generateCode(),
+            ``,
+            `int main() {`,
+            `  std::vector<int> nums{2, 3, 5, 7};`,
+            `  for (const auto num : nums) {`,
+            `    std::cout << num << " ";`,
+            `  }`,
+            `  std::cout << "\\n";`,
+            `  return 0;`,
+            `};`,
+          ].join("\n"),
+        );
+
+        const exeFile = await compileCppSource(mainFile);
+        const output = await runExecutable(exeFile);
+        expect(output).toMatch(/2 3 5 7/);
+      },
+      60000,
+    );
+
+    afterAll(async () => {
+      await Promise.all(testDirs.map((testDir) => testDir.remove()));
+    });
+  });
+});

--- a/src/test/cpp/generate/headers.ts
+++ b/src/test/cpp/generate/headers.ts
@@ -1,0 +1,36 @@
+/**
+ * A class for managing and generating C++ header include directives.
+ */
+export class CppHeaders {
+  #headers: Set<string>;
+
+  /**
+   * Creates an instance of the `CppHeaders` class with the given initial headers.
+   *
+   * @param headers - The initial headers.
+   */
+  constructor(headers: string[]) {
+    this.#headers = new Set<string>(headers);
+  }
+
+  /**
+   * Adds a new header to the object if it doesn't already exist.
+   *
+   * @param header - The new header to add.
+   */
+  add(header: string): void {
+    this.#headers.add(header);
+  }
+
+  /**
+   * Generates C++ code for including headers.
+   *
+   * @returns The generated C++ code.
+   */
+  generateCode(): string {
+    return [...this.#headers]
+      .sort()
+      .map((header) => `#include <${header}>`)
+      .join("\n");
+  }
+}

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -25,10 +25,7 @@ export async function generateCppTest(
     [
       `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,
       ``,
-      [...main.headers]
-        .sort()
-        .map((header) => `#include <${header}>`)
-        .join("\n"),
+      main.headers.generateCode(),
       ``,
       generateCppUtilityCode(schema),
       main.code,

--- a/src/test/cpp/generate/main.test.ts
+++ b/src/test/cpp/generate/main.test.ts
@@ -72,10 +72,7 @@ describe("test C++ main function code generation", () => {
       await fs.writeFile(
         mainFile,
         [
-          [...headers]
-            .sort()
-            .map((header) => `#include <${header}>`)
-            .join("\n"),
+          headers.generateCode(),
           ``,
           `class Solution {`,
           ` public:`,

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,15 +1,16 @@
 import { CppTestSchema } from "../../schema/cpp.js";
 import { formatCpp } from "./format.js";
+import { CppHeaders } from "./headers.js";
 
 /**
  * Generates C++ main function code from a test schema.
  *
  * @param schema - The C++ test schema.
- * @returns An object containing the generated C++ code and a set of required headers.
+ * @returns An object containing the generated C++ code and the required headers.
  */
 export function generateCppMainCode(schema: CppTestSchema): {
   code: string;
-  headers: Set<string>;
+  headers: CppHeaders;
 } {
   return {
     code: [
@@ -42,6 +43,6 @@ export function generateCppMainCode(schema: CppTestSchema): {
       `}`,
       ``,
     ].join("\n"),
-    headers: new Set(["iostream"]),
+    headers: new CppHeaders(["iostream"]),
   };
 }


### PR DESCRIPTION
This pull request resolves #347 by adding a new `CppHeaders` class for managing and generating C++ header include directives. It also modifies the `generateCppMainCode` function to utilize the `CppHeaders` class for holding the required headers, replacing the `Set<string>` type.