### PR TITLE
Add C++ Variable Declaration Generation Function

### DIFF
--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,5 +1,5 @@
 import { CppTestSchema } from "../../schema/cpp.js";
-import { formatCpp } from "./format.js";
+import { generateCppVariableDeclarationCode } from "./variable.js";
 
 /**
  * Generates C++ main function code from a test schema.
@@ -23,15 +23,14 @@ export function generateCppMainCode(schema: CppTestSchema): {
             `  {`,
             `    std::cout << "testing ${c.name}...\\n";`,
             ...c.inputs.map(
-              ({ name, type, value }) =>
-                `    ${type} ${name} = ${formatCpp(value, type)};`,
+              (input) => `    ${generateCppVariableDeclarationCode(input)}`,
             ),
-            `    const ${c.output.type} output = Solution{}.${funName}(${funArgs});`,
-            `    const ${c.output.type} expected = ${formatCpp(c.output.value, c.output.type)};`,
-            `    if (output != expected) {`,
+            `    const ${c.output.type} actualOutput = Solution{}.${funName}(${funArgs});`,
+            `    const ${generateCppVariableDeclarationCode(c.output)}`,
+            `    if (actualOutput != ${c.output.name}) {`,
             `      std::cerr << "failed to test ${c.name}:\\n";`,
-            `      std::cerr << "  output: " << output << "\\n";`,
-            `      std::cerr << "  expected: " << expected << "\\n\\n";`,
+            `      std::cerr << "  actual: " << actualOutput << "\\n";`,
+            `      std::cerr << "  expected: " << ${c.output.name} << "\\n\\n";`,
             `      ++failures;`,
             `    }`,
             `  }`,

--- a/src/test/cpp/generate/variable.test.ts
+++ b/src/test/cpp/generate/variable.test.ts
@@ -123,6 +123,68 @@ describe("generate C++ code for declaring variables", () => {
       expectedCode: `std::vector<std::string> strings = {"foo", "A", "", "123"};`,
       expectedOutput: /foo A {2}123/,
     },
+    {
+      name: "declaring a boolean matrix variable",
+      schema: {
+        name: "booleans",
+        type: "std::vector<std::vector<bool>>",
+        value: [
+          [true, false],
+          [0, 1],
+        ],
+      },
+      expectedCode: `std::vector<std::vector<bool>> booleans = {{true, false}, {0, 1}};`,
+      expectedOutput: /true false {2}false true/,
+    },
+    {
+      name: "declaring a character matrix variable",
+      schema: {
+        name: "characters",
+        type: "std::vector<std::vector<char>>",
+        value: [["A"], [1]],
+      },
+      expectedCode: `std::vector<std::vector<char>> characters = {{'A'}, {'1'}};`,
+      expectedOutput: /A {2}1/,
+    },
+    {
+      name: "declaring an integer matrix variable",
+      schema: {
+        name: "integers",
+        type: "std::vector<std::vector<int>>",
+        value: [
+          [1024, -1024],
+          [0, 0],
+        ],
+      },
+      expectedCode: `std::vector<std::vector<int>> integers = {{1024, -1024}, {0, 0}};`,
+      expectedOutput: /1024 -1024 {2}0 0/,
+    },
+    {
+      name: "declaring a floating-point matrix variable",
+      schema: {
+        name: "floatings",
+        type: "std::vector<std::vector<double>>",
+        value: [
+          [0.125, -0.125],
+          [0, 0],
+        ],
+      },
+      expectedCode: `std::vector<std::vector<double>> floatings = {{0.125, -0.125}, {0, 0}};`,
+      expectedOutput: /0.125 -0.125 {2}0 0/,
+    },
+    {
+      name: "declaring a string matrix variable",
+      schema: {
+        name: "strings",
+        type: "std::vector<std::vector<std::string>>",
+        value: [
+          ["foo", "A"],
+          ["", 123],
+        ],
+      },
+      expectedCode: `std::vector<std::vector<std::string>> strings = {{"foo", "A"}, {"", "123"}};`,
+      expectedOutput: /foo A {3}123/,
+    },
   ];
 
   for (const { name, schema, expectedCode, expectedOutput } of testCases) {

--- a/src/test/cpp/generate/variable.test.ts
+++ b/src/test/cpp/generate/variable.test.ts
@@ -73,6 +73,56 @@ describe("generate C++ code for declaring variables", () => {
       expectedCode: `std::string string = "foo";`,
       expectedOutput: /foo/,
     },
+    {
+      name: "declaring a boolean array variable",
+      schema: {
+        name: "booleans",
+        type: "std::vector<bool>",
+        value: [true, false, 0, 1],
+      },
+      expectedCode: `std::vector<bool> booleans = {true, false, 0, 1};`,
+      expectedOutput: /true false false true/,
+    },
+    {
+      name: "declaring a character array variable",
+      schema: {
+        name: "characters",
+        type: "std::vector<char>",
+        value: ["A", 1],
+      },
+      expectedCode: `std::vector<char> characters = {'A', '1'};`,
+      expectedOutput: /A 1/,
+    },
+    {
+      name: "declaring an integer array variable",
+      schema: {
+        name: "integers",
+        type: "std::vector<int>",
+        value: [1024, -1024, 0],
+      },
+      expectedCode: `std::vector<int> integers = {1024, -1024, 0};`,
+      expectedOutput: /1024 -1024 0/,
+    },
+    {
+      name: "declaring a floating-point array variable",
+      schema: {
+        name: "floatings",
+        type: "std::vector<double>",
+        value: [0.125, -0.125, 0],
+      },
+      expectedCode: `std::vector<double> floatings = {0.125, -0.125, 0};`,
+      expectedOutput: /0.125 -0.125 0/,
+    },
+    {
+      name: "declaring a string array variable",
+      schema: {
+        name: "strings",
+        type: "std::vector<std::string>",
+        value: ["foo", "A", "", 123],
+      },
+      expectedCode: `std::vector<std::string> strings = {"foo", "A", "", "123"};`,
+      expectedOutput: /foo A {2}123/,
+    },
   ];
 
   for (const { name, schema, expectedCode, expectedOutput } of testCases) {
@@ -94,6 +144,15 @@ describe("generate C++ code for declaring variables", () => {
               `#include <iomanip>`,
               `#include <iostream>`,
               `#include <string>`,
+              `#include <vector>`,
+              ``,
+              `template <typename T>`,
+              `std::ostream& operator<<(std::ostream& os, const std::vector<T>& vals) {`,
+              `  for (const auto& val : vals) {`,
+              `    os << val << " ";`,
+              `  }`,
+              `  return os;`,
+              `}`,
               ``,
               `int main() {`,
               `  ${generateCppVariableDeclarationCode(schema)}`,

--- a/src/test/cpp/generate/variable.test.ts
+++ b/src/test/cpp/generate/variable.test.ts
@@ -1,0 +1,119 @@
+import { jest } from "@jest/globals";
+import { createTempDirectory, ITempDirectory } from "create-temp-directory";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { compileCppSource } from "../../../compile/cpp.js";
+import { runExecutable } from "../../../run.js";
+import { CppVariableSchema } from "../../schema/cpp.js";
+import { generateCppVariableDeclarationCode } from "./variable.js";
+
+jest.retryTimes(10);
+
+describe("generate C++ code for declaring variables", () => {
+  const testDirs: ITempDirectory[] = [];
+  const getTestDir = async () => {
+    const testDir = await createTempDirectory();
+    testDirs.push(testDir);
+    return testDir;
+  };
+
+  const testCases: {
+    name: string;
+    schema: CppVariableSchema;
+    expectedCode: string;
+    expectedOutput: RegExp;
+  }[] = [
+    {
+      name: "declaring a boolean variable",
+      schema: {
+        name: "boolean",
+        type: "bool",
+        value: true,
+      },
+      expectedCode: `bool boolean = true;`,
+      expectedOutput: /true/,
+    },
+    {
+      name: "declaring a character variable",
+      schema: {
+        name: "character",
+        type: "char",
+        value: "A",
+      },
+      expectedCode: `char character = 'A';`,
+      expectedOutput: /A/,
+    },
+    {
+      name: "declaring an integer variable",
+      schema: {
+        name: "integer",
+        type: "int",
+        value: 1024,
+      },
+      expectedCode: `int integer = 1024;`,
+      expectedOutput: /1024/,
+    },
+    {
+      name: "declaring a floating-point variable",
+      schema: {
+        name: "floating",
+        type: "double",
+        value: 0.125,
+      },
+      expectedCode: `double floating = 0.125;`,
+      expectedOutput: /0.125/,
+    },
+    {
+      name: "declaring a string variable",
+      schema: {
+        name: "string",
+        type: "std::string",
+        value: "foo",
+      },
+      expectedCode: `std::string string = "foo";`,
+      expectedOutput: /foo/,
+    },
+  ];
+
+  for (const { name, schema, expectedCode, expectedOutput } of testCases) {
+    describe(name, () => {
+      it.concurrent("should generate C++ code", () => {
+        const code = generateCppVariableDeclarationCode(schema);
+        expect(code).toEqual(expectedCode);
+      });
+
+      it.concurrent(
+        "should compile and run the generated C++ code",
+        async () => {
+          const testDir = await getTestDir();
+
+          const mainFile = path.join(testDir.path, "main.cpp");
+          await fs.writeFile(
+            mainFile,
+            [
+              `#include <iomanip>`,
+              `#include <iostream>`,
+              `#include <string>`,
+              ``,
+              `int main() {`,
+              `  ${generateCppVariableDeclarationCode(schema)}`,
+              `  std::cout << std::boolalpha << ${schema.name} << "\\n";`,
+              `  return 0;`,
+              `};`,
+              ``,
+            ].join("\n"),
+          );
+
+          const exeFile = await compileCppSource(mainFile);
+          const output = await runExecutable(exeFile);
+          expect(output).toMatch(expectedOutput);
+        },
+        60000,
+      );
+    });
+  }
+
+  afterAll(async () => {
+    await Promise.all(testDirs.map((testDir) => testDir.remove()));
+  });
+});

--- a/src/test/cpp/generate/variable.ts
+++ b/src/test/cpp/generate/variable.ts
@@ -1,0 +1,14 @@
+import { CppVariableSchema } from "../../schema/cpp.js";
+import { formatCpp } from "./format.js";
+
+/**
+ * Generates C++ code for declaring a variable.
+ *
+ * @param schema - The C++ variable schema.
+ * @returns The generated C++ code.
+ */
+export function generateCppVariableDeclarationCode(
+  schema: CppVariableSchema,
+): string {
+  return `${schema.type} ${schema.name} = ${formatCpp(schema.value, schema.type)};`;
+}


### PR DESCRIPTION
This pull request resolves #350 by adding a new `generateCppVariableDeclarationCode` function for generating C++ variable declaration code from the given variable schema. The function utilizes the `formatCpp` function to determine how to format the variable value in C++.