### PR TITLE
Store C++ Test Inputs and Output as Variable Schema

### DIFF
--- a/src/test/cpp/generate/index.test.ts
+++ b/src/test/cpp/generate/index.test.ts
@@ -27,20 +27,11 @@ it.concurrent(
             name: "sum",
             arguments: ["num1", "num2"],
           },
-          inputs: {
-            num1: {
-              type: "int",
-              value: 12,
-            },
-            num2: {
-              type: "int",
-              value: 5,
-            },
-          },
-          output: {
-            type: "int",
-            value: 17,
-          },
+          inputs: [
+            { name: "num1", type: "int", value: 12 },
+            { name: "num2", type: "int", value: 5 },
+          ],
+          output: { name: "output", type: "int", value: 17 },
         },
         {
           name: "example 2",
@@ -48,20 +39,11 @@ it.concurrent(
             name: "sum",
             arguments: ["num1", "num2"],
           },
-          inputs: {
-            num1: {
-              type: "int",
-              value: -10,
-            },
-            num2: {
-              type: "int",
-              value: 4,
-            },
-          },
-          output: {
-            type: "int",
-            value: -6,
-          },
+          inputs: [
+            { name: "num1", type: "int", value: -10 },
+            { name: "num2", type: "int", value: 4 },
+          ],
+          output: { name: "output", type: "int", value: -6 },
         },
       ],
     };

--- a/src/test/cpp/generate/main.test.ts
+++ b/src/test/cpp/generate/main.test.ts
@@ -29,20 +29,11 @@ describe("test C++ main function code generation", () => {
               name: "sum",
               arguments: ["num1", "num2"],
             },
-            inputs: {
-              num1: {
-                type: "int",
-                value: 12,
-              },
-              num2: {
-                type: "int",
-                value: 5,
-              },
-            },
-            output: {
-              type: "int",
-              value: 17,
-            },
+            inputs: [
+              { name: "num1", type: "int", value: 12 },
+              { name: "num2", type: "int", value: 5 },
+            ],
+            output: { name: "output", type: "int", value: 17 },
           },
           {
             name: "example 2",
@@ -50,20 +41,11 @@ describe("test C++ main function code generation", () => {
               name: "sum",
               arguments: ["num1", "num2"],
             },
-            inputs: {
-              num1: {
-                type: "int",
-                value: -10,
-              },
-              num2: {
-                type: "int",
-                value: 4,
-              },
-            },
-            output: {
-              type: "int",
-              value: -6,
-            },
+            inputs: [
+              { name: "num1", type: "int", value: -10 },
+              { name: "num2", type: "int", value: 4 },
+            ],
+            output: { name: "output", type: "int", value: -6 },
           },
         ],
       });

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -23,9 +23,10 @@ export function generateCppMainCode(schema: CppTestSchema): {
           return [
             `  {`,
             `    std::cout << "testing ${c.name}...\\n";`,
-            ...Object.entries(c.inputs).map(([name, { type, value }]) => {
-              return `    ${type} ${name} = ${formatCpp(value, type)};`;
-            }),
+            ...c.inputs.map(
+              ({ name, type, value }) =>
+                `    ${type} ${name} = ${formatCpp(value, type)};`,
+            ),
             `    const ${c.output.type} output = Solution{}.${funName}(${funArgs});`,
             `    const ${c.output.type} expected = ${formatCpp(c.output.value, c.output.type)};`,
             `    if (output != expected) {`,

--- a/src/test/cpp/generate/utility.test.ts
+++ b/src/test/cpp/generate/utility.test.ts
@@ -19,11 +19,8 @@ it("should generate ostream operator code for functions that return `std::vector
           name: "",
           arguments: [],
         },
-        inputs: {},
-        output: {
-          type: "std::vector<int>",
-          value: null,
-        },
+        inputs: [],
+        output: { name: "output", type: "std::vector<int>", value: null },
       },
     ],
   });

--- a/src/test/schema/cpp.test.ts
+++ b/src/test/schema/cpp.test.ts
@@ -41,20 +41,11 @@ it("should parse a C++ test schema from a raw test schema", () => {
           name: "sum",
           arguments: ["num1", "num2"],
         },
-        inputs: {
-          num1: {
-            type: "int",
-            value: 12,
-          },
-          num2: {
-            type: "int",
-            value: 5,
-          },
-        },
-        output: {
-          type: "int",
-          value: 17,
-        },
+        inputs: [
+          { name: "num1", type: "int", value: 12 },
+          { name: "num2", type: "int", value: 5 },
+        ],
+        output: { name: "output", type: "int", value: 17 },
       },
       {
         name: "example 2",
@@ -62,20 +53,11 @@ it("should parse a C++ test schema from a raw test schema", () => {
           name: "sum",
           arguments: ["num1", "num2"],
         },
-        inputs: {
-          num1: {
-            type: "int",
-            value: -10,
-          },
-          num2: {
-            type: "int",
-            value: 4,
-          },
-        },
-        output: {
-          type: "int",
-          value: -6,
-        },
+        inputs: [
+          { name: "num1", type: "int", value: -10 },
+          { name: "num2", type: "int", value: 4 },
+        ],
+        output: { name: "output", type: "int", value: -6 },
       },
     ],
   });

--- a/src/test/schema/cpp.ts
+++ b/src/test/schema/cpp.ts
@@ -1,5 +1,10 @@
 import { RawTestSchema } from "./raw.js";
 
+export interface CppVariableSchema {
+  type: string;
+  value: unknown;
+}
+
 export interface CppTestSchema {
   cases: {
     name: string;
@@ -7,8 +12,8 @@ export interface CppTestSchema {
       name: string;
       arguments: string[];
     };
-    inputs: Record<string, { type: string; value: unknown }>;
-    output: { type: string; value: unknown };
+    inputs: Record<string, CppVariableSchema>;
+    output: CppVariableSchema;
   }[];
 }
 

--- a/src/test/schema/cpp.ts
+++ b/src/test/schema/cpp.ts
@@ -1,6 +1,7 @@
 import { RawTestSchema } from "./raw.js";
 
 export interface CppVariableSchema {
+  name: string;
   type: string;
   value: unknown;
 }
@@ -12,7 +13,7 @@ export interface CppTestSchema {
       name: string;
       arguments: string[];
     };
-    inputs: Record<string, CppVariableSchema>;
+    inputs: CppVariableSchema[];
     output: CppVariableSchema;
   }[];
 }
@@ -29,12 +30,13 @@ export function parseCppTestSchema(rawSchema: RawTestSchema): CppTestSchema {
       return {
         name,
         function: rawSchema.cpp.function,
-        inputs: Object.fromEntries(
-          Object.entries(inputs).map(([name, value]) => {
-            return [name, { type: rawSchema.cpp.inputs[name], value }];
-          }),
-        ),
+        inputs: Object.entries(inputs).map(([name, value]) => ({
+          name,
+          type: rawSchema.cpp.inputs[name],
+          value,
+        })),
         output: {
+          name: "output",
           type: rawSchema.cpp.output,
           value: output,
         },


### PR DESCRIPTION
This pull request resolves #353 by adding a new `CppVariableSchema` type, which is utilized in the `inputs` and `output` properties of the `cases` elements of the `CppTestSchema` type. The `CppVariableSchema` type contains a name, type, and value required for declaring a variable with a specific type and value.