### PR TITLE
Add Generate C++ Include Headers Code Function

### DIFF
--- a/src/test/cpp/generate/headers.test.ts
+++ b/src/test/cpp/generate/headers.test.ts
@@ -4,74 +4,9 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource } from "../../../compile/cpp.js";
 import { runExecutable } from "../../../run.js";
-import { CppHeaders, generateCppIncludeHeadersCode } from "./headers.js";
+import { generateCppIncludeHeadersCode } from "./headers.js";
 
 jest.retryTimes(10);
-
-describe("generate C++ code for including headers", () => {
-  it.concurrent("should generate C++ code for including headers", () => {
-    const headers = new CppHeaders(["iostream", "vector"]);
-    expect(headers.generateCode()).toEqual(
-      `#include <iostream>\n#include <vector>`,
-    );
-  });
-
-  it.concurrent(
-    "should generate C++ code for including headers after inserting a new header",
-    () => {
-      const headers = new CppHeaders(["iostream", "vector"]);
-      headers.add("string");
-
-      expect(headers.generateCode()).toEqual(
-        `#include <iostream>\n#include <string>\n#include <vector>`,
-      );
-    },
-  );
-
-  describe("compile the generated C++ code for including headers", () => {
-    const testDirs: ITempDirectory[] = [];
-    const getTestDir = async () => {
-      const testDir = await createTempDirectory();
-      testDirs.push(testDir);
-      return testDir;
-    };
-
-    it.concurrent(
-      "should compile the generated C++ code for including headers",
-      async () => {
-        const testDir = await getTestDir();
-
-        const headers = new CppHeaders(["iostream", "vector"]);
-
-        const mainFile = path.join(testDir.path, "main.cpp");
-        await fs.writeFile(
-          mainFile,
-          [
-            headers.generateCode(),
-            ``,
-            `int main() {`,
-            `  std::vector<int> nums{2, 3, 5, 7};`,
-            `  for (const auto num : nums) {`,
-            `    std::cout << num << " ";`,
-            `  }`,
-            `  std::cout << "\\n";`,
-            `  return 0;`,
-            `};`,
-          ].join("\n"),
-        );
-
-        const exeFile = await compileCppSource(mainFile);
-        const output = await runExecutable(exeFile);
-        expect(output).toMatch(/2 3 5 7/);
-      },
-      60000,
-    );
-
-    afterAll(async () => {
-      await Promise.all(testDirs.map((testDir) => testDir.remove()));
-    });
-  });
-});
 
 describe("generate C++ code for including headers", () => {
   it.concurrent("should generate C++ code for including headers", () => {

--- a/src/test/cpp/generate/headers.test.ts
+++ b/src/test/cpp/generate/headers.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource } from "../../../compile/cpp.js";
 import { runExecutable } from "../../../run.js";
-import { CppHeaders } from "./headers.js";
+import { CppHeaders, generateCppIncludeHeadersCode } from "./headers.js";
 
 jest.retryTimes(10);
 
@@ -57,6 +57,58 @@ describe("generate C++ code for including headers", () => {
             `  std::cout << "\\n";`,
             `  return 0;`,
             `};`,
+          ].join("\n"),
+        );
+
+        const exeFile = await compileCppSource(mainFile);
+        const output = await runExecutable(exeFile);
+        expect(output).toMatch(/2 3 5 7/);
+      },
+      60000,
+    );
+
+    afterAll(async () => {
+      await Promise.all(testDirs.map((testDir) => testDir.remove()));
+    });
+  });
+});
+
+describe("generate C++ code for including headers", () => {
+  it.concurrent("should generate C++ code for including headers", () => {
+    const headers = new Set(["vector", "iostream"]);
+    expect(generateCppIncludeHeadersCode(headers)).toEqual(
+      `#include <iostream>\n#include <vector>`,
+    );
+  });
+
+  describe("compile the generated C++ code for including headers", () => {
+    const testDirs: ITempDirectory[] = [];
+    const getTestDir = async () => {
+      const testDir = await createTempDirectory();
+      testDirs.push(testDir);
+      return testDir;
+    };
+
+    it.concurrent(
+      "should compile the generated C++ code for including headers",
+      async () => {
+        const testDir = await getTestDir();
+
+        const mainFile = path.join(testDir.path, "main.cpp");
+        await fs.writeFile(
+          mainFile,
+          [
+            generateCppIncludeHeadersCode(new Set(["vector", "iostream"])),
+            ``,
+            `int main() {`,
+            `  std::vector<int> nums{2, 3, 5, 7};`,
+            `  for (const auto num : nums) {`,
+            `    std::cout << num << " ";`,
+            `  }`,
+            `  std::cout << "\\n";`,
+            `  return 0;`,
+            `};`,
+            ``,
           ].join("\n"),
         );
 

--- a/src/test/cpp/generate/headers.ts
+++ b/src/test/cpp/generate/headers.ts
@@ -34,3 +34,16 @@ export class CppHeaders {
       .join("\n");
   }
 }
+
+/**
+ * Generates C++ code for including headers.
+ *
+ * @param headers - Set of headers to include.
+ * @returns The generated C++ code.
+ */
+export function generateCppIncludeHeadersCode(headers: Set<string>): string {
+  return [...headers]
+    .sort()
+    .map((header) => `#include <${header}>`)
+    .join("\n");
+}

--- a/src/test/cpp/generate/headers.ts
+++ b/src/test/cpp/generate/headers.ts
@@ -1,41 +1,4 @@
 /**
- * A class for managing and generating C++ header include directives.
- */
-export class CppHeaders {
-  #headers: Set<string>;
-
-  /**
-   * Creates an instance of the `CppHeaders` class with the given initial headers.
-   *
-   * @param headers - The initial headers.
-   */
-  constructor(headers: string[]) {
-    this.#headers = new Set<string>(headers);
-  }
-
-  /**
-   * Adds a new header to the object if it doesn't already exist.
-   *
-   * @param header - The new header to add.
-   */
-  add(header: string): void {
-    this.#headers.add(header);
-  }
-
-  /**
-   * Generates C++ code for including headers.
-   *
-   * @returns The generated C++ code.
-   */
-  generateCode(): string {
-    return [...this.#headers]
-      .sort()
-      .map((header) => `#include <${header}>`)
-      .join("\n");
-  }
-}
-
-/**
  * Generates C++ code for including headers.
  *
  * @param headers - Set of headers to include.

--- a/src/test/cpp/generate/index.ts
+++ b/src/test/cpp/generate/index.ts
@@ -1,6 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { CppTestSchema } from "../../schema/cpp.js";
+import { generateCppIncludeHeadersCode } from "./headers.js";
 import { generateCppMainCode } from "./main.js";
 import { generateCppUtilityCode } from "./utility.js";
 
@@ -25,7 +26,7 @@ export async function generateCppTest(
     [
       `#include "${path.relative(path.dirname(outFile), solutionFile)}"`,
       ``,
-      main.headers.generateCode(),
+      generateCppIncludeHeadersCode(main.headers),
       ``,
       generateCppUtilityCode(schema),
       main.code,

--- a/src/test/cpp/generate/main.test.ts
+++ b/src/test/cpp/generate/main.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { compileCppSource } from "../../../compile/cpp.js";
 import { runExecutable } from "../../../run.js";
+import { generateCppIncludeHeadersCode } from "./headers.js";
 import { generateCppMainCode } from "./main.js";
 
 jest.retryTimes(10);
@@ -54,7 +55,7 @@ describe("test C++ main function code generation", () => {
       await fs.writeFile(
         mainFile,
         [
-          headers.generateCode(),
+          generateCppIncludeHeadersCode(headers),
           ``,
           `class Solution {`,
           ` public:`,

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -1,6 +1,5 @@
 import { CppTestSchema } from "../../schema/cpp.js";
 import { formatCpp } from "./format.js";
-import { CppHeaders } from "./headers.js";
 
 /**
  * Generates C++ main function code from a test schema.
@@ -10,7 +9,7 @@ import { CppHeaders } from "./headers.js";
  */
 export function generateCppMainCode(schema: CppTestSchema): {
   code: string;
-  headers: CppHeaders;
+  headers: Set<string>;
 } {
   return {
     code: [
@@ -44,6 +43,6 @@ export function generateCppMainCode(schema: CppTestSchema): {
       `}`,
       ``,
     ].join("\n"),
-    headers: new CppHeaders(["iostream"]),
+    headers: new Set(["iostream"]),
   };
 }


### PR DESCRIPTION
This pull request resolves #357 by adding a new `generateCppIncludeHeadersCode` function, replacing the `generateCode` method of the `CppHeaders` class.