### PR TITLE
Return Required Headers in Generate C++ Variable Declaration Code Function

### DIFF
--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -11,6 +11,7 @@ export function generateCppMainCode(schema: CppTestSchema): {
   code: string;
   headers: Set<string>;
 } {
+  let headers = new Set<string>(["iostream"]);
   return {
     code: [
       `int main() {`,
@@ -22,9 +23,14 @@ export function generateCppMainCode(schema: CppTestSchema): {
           return [
             `  {`,
             `    std::cout << "testing ${c.name}...\\n";`,
-            ...[...c.inputs, c.output].map(
-              (input) => `    ${generateCppVariableDeclarationCode(input)}`,
-            ),
+            ...[...c.inputs, c.output].map((input) => {
+              const varDeclaration = generateCppVariableDeclarationCode(input);
+              headers = new Set<string>([
+                ...headers,
+                ...varDeclaration.requiredHeaders,
+              ]);
+              return `    ${varDeclaration.code}`;
+            }),
             `    const ${c.output.type} actualOutput = Solution{}.${funName}(${funArgs});`,
             `    if (actualOutput != ${c.output.name}) {`,
             `      std::cerr << "failed to test ${c.name}:\\n";`,
@@ -41,6 +47,6 @@ export function generateCppMainCode(schema: CppTestSchema): {
       `}`,
       ``,
     ].join("\n"),
-    headers: new Set(["iostream"]),
+    headers,
   };
 }

--- a/src/test/cpp/generate/main.ts
+++ b/src/test/cpp/generate/main.ts
@@ -22,11 +22,10 @@ export function generateCppMainCode(schema: CppTestSchema): {
           return [
             `  {`,
             `    std::cout << "testing ${c.name}...\\n";`,
-            ...c.inputs.map(
+            ...[...c.inputs, c.output].map(
               (input) => `    ${generateCppVariableDeclarationCode(input)}`,
             ),
             `    const ${c.output.type} actualOutput = Solution{}.${funName}(${funArgs});`,
-            `    const ${generateCppVariableDeclarationCode(c.output)}`,
             `    if (actualOutput != ${c.output.name}) {`,
             `      std::cerr << "failed to test ${c.name}:\\n";`,
             `      std::cerr << "  actual: " << actualOutput << "\\n";`,

--- a/src/test/cpp/generate/variable.ts
+++ b/src/test/cpp/generate/variable.ts
@@ -4,26 +4,34 @@ import { CppVariableSchema } from "../../schema/cpp.js";
  * Generates C++ code for declaring a variable.
  *
  * @param schema - The C++ variable schema.
- * @returns The generated C++ code.
+ * @returns An object containing the generated C++ code and the required headers.
  */
-export function generateCppVariableDeclarationCode(
-  schema: CppVariableSchema,
-): string {
-  function formatValue(value: unknown, type: string): string {
+export function generateCppVariableDeclarationCode(schema: CppVariableSchema): {
+  code: string;
+  requiredHeaders: Set<string>;
+} {
+  const requiredHeaders = new Set<string>();
+
+  const formatValue = (value: unknown, type: string): string => {
     switch (type) {
       case "std::string":
+        requiredHeaders.add("string");
         return `"${value}"`;
       case "char":
         return `'${value}'`;
     }
 
     if (type.match(/^std::vector<.*>$/)) {
+      requiredHeaders.add("vector");
       const subtype = type.substring(12, type.length - 1);
       return `{${(value as unknown[]).map((v) => formatValue(v, subtype)).join(", ")}}`;
     }
 
     return `${value}`;
-  }
+  };
 
-  return `${schema.type} ${schema.name} = ${formatValue(schema.value, schema.type)};`;
+  return {
+    code: `${schema.type} ${schema.name} = ${formatValue(schema.value, schema.type)};`,
+    requiredHeaders,
+  };
 }


### PR DESCRIPTION
This pull request resolves #363 by modifying the `generateCppVariableDeclarationCode` function to return the required headers alongside the generated C++ code. It also merges the input and output variable declarations in the `generateCppMainCode` function to simplify the usage of the required headers.