### PR TITLE
Remove Windows Support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,11 +30,7 @@ jobs:
 
   test-package:
     name: Test Package
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, ubuntu-22.04, macos-14]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -52,11 +48,7 @@ jobs:
 
   test-sample:
     name: Test Sample
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-2022, ubuntu-22.04, macos-14]
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2

--- a/src/compile/utils.test.ts
+++ b/src/compile/utils.test.ts
@@ -42,29 +42,9 @@ describe("find an executable file", () => {
 });
 
 describe("retrieve an executable file path", () => {
-  let originalPlatform: string | undefined = undefined;
-  const mockPlatform = (newPlatform: string) => {
-    if (originalPlatform === undefined) originalPlatform = process.platform;
-    Object.defineProperty(process, "platform", { value: newPlatform });
-  };
-
-  it("should retrieve an executable file path on Windows platform", () => {
-    mockPlatform("win32");
-    expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
-      path.join("path", "to", "main.exe"),
-    );
-  });
-
-  it("should retrieve an executable file path on non-Windows platform", () => {
-    mockPlatform("non-win32");
+  it("should retrieve an executable file path", () => {
     expect(getExecutableFromSource(path.join("path", "to", "main.cpp"))).toBe(
       path.join("path", "to", "main"),
     );
-  });
-
-  afterEach(() => {
-    if (originalPlatform !== undefined) {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
-    }
   });
 });

--- a/src/compile/utils.ts
+++ b/src/compile/utils.ts
@@ -29,7 +29,5 @@ export async function findExecutable(
  * @returns The executable file path corresponding to the C++ source file.
  */
 export function getExecutableFromSource(sourceFile: string): string {
-  let executableFile = sourceFile.replace(path.extname(sourceFile), "");
-  if (process.platform === "win32") executableFile += ".exe";
-  return executableFile;
+  return sourceFile.replace(path.extname(sourceFile), "");
 }


### PR DESCRIPTION
This pull request resolves #490 by removing Windows support as follows:  
- Modifies GitHub Action workflows to run only on Ubuntu runners.  
- Removes support for handling the Windows platform in the `getExecutableFromSource` function.