### PR TITLE
Replace tsx with vite-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "prepack": "tsc",
-    "start": "tsx src/bin.ts",
+    "start": "vite-node src/bin.ts",
     "test": "vitest"
   },
   "dependencies": {
@@ -41,9 +41,9 @@
     "eslint": "^9.22.0",
     "lefthook": "^1.11.3",
     "prettier": "^3.5.2",
-    "tsx": "^4.19.3",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.27.0",
+    "vite-node": "^3.0.9",
     "vitest": "^3.0.7"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,15 +39,15 @@ importers:
       prettier:
         specifier: ^3.5.2
         version: 3.5.3
-      tsx:
-        specifier: ^4.19.3
-        version: 4.19.3
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
       typescript-eslint:
         specifier: ^8.27.0
         version: 8.27.0(eslint@9.22.0)(typescript@5.8.2)
+      vite-node:
+        specifier: ^3.0.9
+        version: 3.0.9(@types/node@22.13.10)(tsx@4.19.3)
       vitest:
         specifier: ^3.0.7
         version: 3.0.7(@types/node@22.13.10)(tsx@4.19.3)
@@ -1346,6 +1346,11 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite-node@3.0.9:
+    resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite@6.1.0:
     resolution: {integrity: sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -2089,6 +2094,7 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.0
       '@esbuild/win32-ia32': 0.25.0
       '@esbuild/win32-x64': 0.25.0
+    optional: true
 
   escalade@3.2.0: {}
 
@@ -2218,6 +2224,7 @@ snapshots:
   get-tsconfig@4.10.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -2483,7 +2490,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   reusify@1.1.0: {}
 
@@ -2590,6 +2598,7 @@ snapshots:
       get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   type-check@0.4.0:
     dependencies:
@@ -2614,6 +2623,27 @@ snapshots:
       punycode: 2.3.1
 
   vite-node@3.0.7(@types/node@22.13.10)(tsx@4.19.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.6.0
+      pathe: 2.0.3
+      vite: 6.1.0(@types/node@22.13.10)(tsx@4.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.0.9(@types/node@22.13.10)(tsx@4.19.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0


### PR DESCRIPTION
This pull request resolves #608 by replacing [tsx](https://www.npmjs.com/package/tsx) with [vite-node](https://www.npmjs.com/package/vite-node) for executing the `src/bin.ts` file.