### PR TITLE
Remove Upload Package Step in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,8 +32,3 @@ jobs:
 
       - name: Package Library
         run: pnpm pack
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: package.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ build/
 dist/
 node_modules/
 
-package.tgz
+*.tgz


### PR DESCRIPTION
This pull request resolves #613 by removing the "Upload Package" step from the `build` workflow. Additionally, this change also updates the project to ignore the default output name for packaging the library.