### PR TITLE
Remove Unnecessary Configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,5 @@ export default [
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
   ...tseslint.configs.stylistic,
-  {
-    ignores: [".*", "dist"],
-  },
+  { ignores: ["dist"] },
 ];

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "scripts": {
     "prepack": "tsc",
     "start": "vite-node src/bin.ts",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "commander": "^13.1.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    watch: false,
     coverage: {
       all: false,
       enabled: true,


### PR DESCRIPTION
This pull request resolves #622 by removing the following configurations:  
- Removing `.*` files from being ignored in `eslint.config.js`.  
- Removing the `watch` option set to `false` in `vitest.config.ts`.