### PR TITLE
Modify Solution Files to Be Searched Based on Directory

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -7,11 +7,9 @@ program
   .name("leettest")
   .version("0.2.0")
   .description("Compile and test solutions to LeetCode problems")
-  .argument("[files...]", "A list of pattern for solution files to process", [
-    "**/solution.cpp",
-  ])
-  .action(async (files) => {
-    const solutionFiles = await testSolutions(files);
+  .argument("[dir]", "The root directory to search for solution files", ".")
+  .action(async (dir) => {
+    const solutionFiles = await testSolutions(dir);
     for (const solutionFile of solutionFiles) {
       console.info(`Found ${solutionFile}`);
     }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,13 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, expect, it } from "vitest";
 import { testSolutions } from "./index.js";
 
-let tempDir: string;
-beforeAll(async () => {
-  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "temp"));
-});
+const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "temp"));
 
 it("should test solutions", async () => {
   const solutionDir = path.join(tempDir, "multiply_integers");
@@ -26,13 +23,8 @@ it("should test solutions", async () => {
     ].join("\n"),
   );
 
-  const solutionFiles = await testSolutions([
-    path.join(tempDir, "**", "solution.cpp"),
-  ]);
-
+  const solutionFiles = await testSolutions(tempDir);
   expect(solutionFiles).toEqual([path.join(solutionDir, "solution.cpp")]);
 });
 
-afterAll(async () => {
-  await fs.rmdir(tempDir, { recursive: true });
-});
+afterAll(() => fs.rmdir(tempDir, { recursive: true }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,7 @@
-import { globSync } from "glob";
+import { glob } from "glob";
+import path from "node:path";
 
-export async function testSolutions(patterns: string[]): Promise<string[]> {
+export async function testSolutions(dir: string): Promise<string[]> {
   // TODO: It currently only returns the list of solution files.
-  return patterns
-    .map((pattern) => globSync(pattern))
-    .flat()
-    .sort();
+  return glob(path.join(dir, "**", "solution.cpp"));
 }


### PR DESCRIPTION
This pull request resolves #635 by modifying the `testSolutions` function to search solution files based on the root directory instead of glob pattern.