### PR TITLE
Add Utility Function for Hierarchical Temp File Structure

### DIFF
--- a/src/internal/temp-fs.test.ts
+++ b/src/internal/temp-fs.test.ts
@@ -1,0 +1,41 @@
+import { rm, readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { afterAll, expect, test } from "vitest";
+import { createTempFs } from "./temp-fs.js";
+
+let tempDir: string | undefined;
+
+function expectReadDir(...paths: string[]) {
+  return expect(readdir(path.join(...paths))).resolves;
+}
+
+function expectReadFile(...paths: string[]) {
+  return expect(readFile(path.join(...paths), "utf-8")).resolves;
+}
+
+test("create temporary file system", async () => {
+  tempDir = await createTempFs({
+    dir1: {
+      dir1: {
+        file1: ["line1", "line2"],
+        file2: "line",
+      },
+      file1: "line",
+    },
+    dir2: {},
+    file1: "",
+  });
+
+  await Promise.all([
+    expectReadDir(tempDir).toStrictEqual(["dir1", "dir2", "file1"]),
+    expectReadDir(tempDir, "dir1").toStrictEqual(["dir1", "file1"]),
+    expectReadDir(tempDir, "dir1", "dir1").toStrictEqual(["file1", "file2"]),
+    expectReadFile(tempDir, "dir1", "dir1", "file1").toBe("line1\nline2\n"),
+    expectReadFile(tempDir, "dir1", "dir1", "file2").toBe("line\n"),
+    expectReadFile(tempDir, "dir1", "file1").toBe("line\n"),
+    expectReadDir(tempDir, "dir2").toStrictEqual([]),
+    expectReadFile(tempDir, "file1").toBe("\n"),
+  ]);
+});
+
+afterAll(() => tempDir && rm(tempDir, { recursive: true }));

--- a/src/internal/temp-fs.ts
+++ b/src/internal/temp-fs.ts
@@ -1,0 +1,30 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+export interface FsTree {
+  [key: string]: FsTree | string | string[];
+}
+
+export async function createTempFs(tree: FsTree): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "temp"));
+  await createTempFsRecursively(dir, tree);
+  return dir;
+}
+
+async function createTempFsRecursively(dir: string, tree: FsTree) {
+  await Promise.all(
+    Object.entries(tree).map(async ([key, val]) => {
+      if (typeof val === "object") {
+        if (Array.isArray(val)) {
+          return writeFile(path.join(dir, key), `${val.join("\n")}\n`);
+        } else {
+          await mkdir(path.join(dir, key));
+          return createTempFsRecursively(path.join(dir, key), val);
+        }
+      } else {
+        return writeFile(path.join(dir, key), `${val}\n`);
+      }
+    }),
+  );
+}


### PR DESCRIPTION
This pull request resolves #645 by introducing a new `createTempFs` utility function for creating hierarchical temp file structure. This change also modifies the test in the `solution.test.ts` file to utilize that function.