### PR TITLE
Return Status When Testing Solution files

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -7,11 +7,14 @@ program
   .name("leettest")
   .version("0.2.0")
   .description("Compile and test solutions to LeetCode problems")
-  .argument("[dir]", "The root directory to search for solution files", ".")
-  .action(async (dir) => {
-    const solutionFiles = await testSolutions(dir);
-    for (const solutionFile of solutionFiles) {
-      console.info(`Found ${solutionFile}`);
+  .argument("[root]", "The root directory to search for solution files", ".")
+  .action(async (root) => {
+    for await (const { dir, err } of testSolutions(root)) {
+      if (err == null) {
+        console.info(`Tested ${dir}`);
+      } else {
+        console.error(`Failed to test ${dir}:`, err);
+      }
     }
   })
   .parse();

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,1 +1,1 @@
-export { testSolutions } from "./solution.js";
+export { type TestResult, testSolutions } from "./solution.js";

--- a/src/solution.test.ts
+++ b/src/solution.test.ts
@@ -1,7 +1,7 @@
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { afterAll, expect, test } from "vitest";
-import { testSolutions } from "./solution.js";
+import { type TestResult, testSolutions } from "./solution.js";
 import { createTempFs } from "./internal/temp-fs.js";
 
 const tempDir = await createTempFs({
@@ -21,11 +21,15 @@ const tempDir = await createTempFs({
 });
 
 test("test solutions", async () => {
-  const solutionFiles = await testSolutions(tempDir);
-  expect(solutionFiles).toEqual([
-    path.join(tempDir, "bar", "solution.cpp"),
-    path.join(tempDir, "foo", "bar", "solution.cpp"),
-    path.join(tempDir, "foo", "solution.cpp"),
+  const results: TestResult[] = [];
+  for await (const result of testSolutions(tempDir)) {
+    results.push(result);
+  }
+
+  expect(results).toEqual([
+    { dir: path.join(tempDir, "bar", "solution.cpp"), err: null },
+    { dir: path.join(tempDir, "foo", "solution.cpp"), err: null },
+    { dir: path.join(tempDir, "foo", "bar", "solution.cpp"), err: null },
   ]);
 });
 


### PR DESCRIPTION
This pull request resolves #651 by modifying the `testSolutions` function to yield status when testing solution files.