### PR TITLE
Run Compiled Executable When Testing Solutions

### DIFF
--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { CompileError, OutputError, ProcessError } from "./errors.js";
+import { CompileError, OutputError, ProcessError, RunError } from "./errors.js";
 
-test("create a compile error", () => {
+test("create a compile error", { concurrent: true }, () => {
   const err = new CompileError([new Error()], "main.cpp");
   expect(err.name).toBe("CompileError");
   expect(err.message).toBe("Failed to compile: main.cpp");
@@ -28,4 +28,11 @@ describe("create process errors", { concurrent: true }, () => {
     expect(err.message).toBe("Process failed: cmd arg0 arg1");
     expect(err.errors).toStrictEqual([new Error()]);
   });
+});
+
+test("create a run error", { concurrent: true }, () => {
+  const err = new RunError([new Error()], "main");
+  expect(err.name).toBe("RunError");
+  expect(err.message).toBe("Failed to run: main");
+  expect(err.errors).toStrictEqual([new Error()]);
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -37,3 +37,16 @@ export class ProcessError extends AggregateError {
     Error.captureStackTrace?.(this, this.constructor);
   }
 }
+
+export class RunError extends AggregateError {
+  file: string;
+
+  constructor(error: unknown[], file: string) {
+    super(error, `Failed to run: ${file}`);
+
+    this.name = this.constructor.name;
+    this.file = file;
+
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}

--- a/src/internal/solution.test.ts
+++ b/src/internal/solution.test.ts
@@ -1,13 +1,13 @@
 import { rm } from "node:fs/promises";
 import path from "node:path";
 import { afterAll, describe, expect, test } from "vitest";
-import { CompileError } from "../errors.js";
+import { CompileError, RunError } from "../errors.js";
 import { testCppSolution } from "./solution.js";
 import { createTempFs } from "./temp-fs.js";
 
 describe(
   "test C++ solutions",
-  { concurrent: true, timeout: 15000 },
+  { concurrent: true, timeout: 30000 },
   async () => {
     const tempDir = await createTempFs({
       success: {
@@ -15,6 +15,9 @@ describe(
       },
       compile_error: {
         "test.cpp": "int main() {",
+      },
+      run_error: {
+        "test.cpp": "int main() { return 1; }",
       },
     });
 
@@ -24,6 +27,11 @@ describe(
       expect(
         testCppSolution(path.join(tempDir, "compile_error")),
       ).rejects.toThrow(CompileError));
+
+    test("run error", () =>
+      expect(testCppSolution(path.join(tempDir, "run_error"))).rejects.toThrow(
+        RunError,
+      ));
 
     afterAll(() => rm(tempDir, { recursive: true }));
   },

--- a/src/internal/solution.ts
+++ b/src/internal/solution.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { CompileError } from "../errors.js";
+import { CompileError, RunError } from "../errors.js";
 import { waitProcess } from "./process.js";
 
 export async function testCppSolution(dir: string): Promise<void> {
@@ -20,5 +20,12 @@ export async function testCppSolution(dir: string): Promise<void> {
     await waitProcess(proc);
   } catch (err) {
     throw new CompileError([err], testCppFile);
+  }
+
+  try {
+    const proc = spawn(executableFile);
+    await waitProcess(proc);
+  } catch (err) {
+    throw new RunError([err], executableFile);
   }
 }

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,2 +1,2 @@
-export { CompileError, OutputError, ProcessError } from "./errors.js";
+export { CompileError, OutputError, ProcessError, RunError } from "./errors.js";
 export { type TestResult, testSolutions } from "./solution.js";


### PR DESCRIPTION
This pull request resolves #653 by modifying the `testCppSolution` function to run the compiled executable. It also introduces a new `RunError` class to handle runtime errors within the project.