### PR TITLE
Format Test Result Log

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,6 +2,7 @@
 
 import { program } from "commander";
 import { testSolutions } from "./solution.js";
+import { stringifyError } from "./internal/stringify.js";
 
 program
   .name("leettest")
@@ -11,9 +12,11 @@ program
   .action(async (root) => {
     for await (const { dir, err } of testSolutions(root)) {
       if (err) {
-        console.error(`Failed to test ${dir}:`, err);
+        process.stderr.write(
+          `✖ Failed to test ${dir}\n${stringifyError(err, "  ")}\n`,
+        );
       } else {
-        console.info(`Tested ${dir}`);
+        process.stdout.write(`✔ Tested ${dir}\n`);
       }
     }
   })

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { CompileError, OutputError, ProcessError, RunError } from "./errors.js";
+import { CompileError, ProcessError, RunError } from "./errors.js";
 
 test("create a compile error", { concurrent: true }, () => {
   const err = new CompileError([new Error()], "main.cpp");
@@ -8,25 +8,17 @@ test("create a compile error", { concurrent: true }, () => {
   expect(err.errors).toStrictEqual([new Error()]);
 });
 
-test("create an output error", { concurrent: true }, () => {
-  const err = new OutputError(Buffer.from("a message"));
-  expect(err.name).toBe("OutputError");
-  expect(err.message).toBe("a message");
-});
-
 describe("create process errors", { concurrent: true }, () => {
-  test("with code", () => {
-    const err = new ProcessError([new Error()], ["cmd", "arg0", "arg1"], 9);
+  test("with code and output", () => {
+    const err = new ProcessError(["cmd", "arg0", "arg1"], 9, " an output\n");
     expect(err.name).toBe("ProcessError");
-    expect(err.message).toBe("Process failed (9): cmd arg0 arg1");
-    expect(err.errors).toStrictEqual([new Error()]);
+    expect(err.message).toBe("Process failed (9): cmd arg0 arg1\nan output");
   });
 
-  test("without code", () => {
-    const err = new ProcessError([new Error()], ["cmd", "arg0", "arg1"], null);
+  test("without code and output", () => {
+    const err = new ProcessError(["cmd", "arg0", "arg1"], null, "\n");
     expect(err.name).toBe("ProcessError");
     expect(err.message).toBe("Process failed: cmd arg0 arg1");
-    expect(err.errors).toStrictEqual([new Error()]);
   });
 });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -11,28 +11,25 @@ export class CompileError extends AggregateError {
   }
 }
 
-export class OutputError extends Error {
-  constructor(buffer: Buffer) {
-    super(buffer.toString());
-    this.name = this.constructor.name;
-    Error.captureStackTrace?.(this, this.constructor);
-  }
-}
-
-export class ProcessError extends AggregateError {
+export class ProcessError extends Error {
   args: readonly string[];
   code: number | null;
+  output: string;
 
-  constructor(errs: unknown[], args: readonly string[], code: number | null) {
+  constructor(args: readonly string[], code: number | null, output: string) {
     let message = "Process failed";
     if (code !== null) message += ` (${code})`;
     message += `: ${args.join(" ")}`;
 
-    super(errs, message);
+    const trimmedOutput = output.trim();
+    if (trimmedOutput !== "") message += `\n${trimmedOutput}`;
+
+    super(message);
 
     this.name = this.constructor.name;
     this.args = args;
     this.code = code;
+    this.output = output;
 
     Error.captureStackTrace?.(this, this.constructor);
   }

--- a/src/internal/process.ts
+++ b/src/internal/process.ts
@@ -1,5 +1,5 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
-import { OutputError, ProcessError } from "../errors.js";
+import { ProcessError } from "../errors.js";
 
 export async function waitProcess(
   proc: ChildProcessWithoutNullStreams,
@@ -14,9 +14,8 @@ export async function waitProcess(
       if (code === 0) {
         resolve();
       } else {
-        const errs =
-          chunks.length > 0 ? [new OutputError(Buffer.concat(chunks))] : [];
-        reject(new ProcessError(errs, proc.spawnargs, code));
+        const output = Buffer.concat(chunks).toString();
+        reject(new ProcessError(proc.spawnargs, code, output));
       }
     });
   });

--- a/src/internal/stringify.test.ts
+++ b/src/internal/stringify.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { stringifyError } from "./stringify.js";
+
+describe("stringify errors", { concurrent: true }, () => {
+  test("error", () => {
+    const err = new Error("an error\na description");
+    expect(stringifyError(err, "  ")).toBe("  an error\n  a description");
+  });
+
+  test("aggregated error", () => {
+    const err = new AggregateError(
+      [new Error("an error"), new Error("another error\na description")],
+      "an error\na description",
+    );
+
+    expect(stringifyError(err, "  ")).toBe(
+      [
+        "  an error",
+        "  a description",
+        "  ✖ an error",
+        "  ✖ another error",
+        "    a description",
+      ].join("\n"),
+    );
+  });
+
+  test("unknown error", () => {
+    expect(stringifyError("unknown", "  ")).toBe("  Unknown reason");
+  });
+});

--- a/src/internal/stringify.ts
+++ b/src/internal/stringify.ts
@@ -1,0 +1,16 @@
+export function stringifyError(err: unknown, indent: string): string {
+  if (err instanceof Error) {
+    let message = err.message;
+    if (err instanceof AggregateError && err.errors.length > 0) {
+      message += "\n";
+      message += err.errors
+        .map((err) => "✖" + stringifyError(err, "  ").slice(1))
+        .join("\n");
+    }
+    return message
+      .split("\n")
+      .map((line) => `${indent}${line}`)
+      .join("\n");
+  }
+  return `${indent}Unknown reason`;
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,2 +1,2 @@
-export { CompileError, OutputError, ProcessError, RunError } from "./errors.js";
+export { CompileError, ProcessError, RunError } from "./errors.js";
 export { type TestResult, testSolutions } from "./solution.js";


### PR DESCRIPTION
This pull request resolves #655 by modifying the binary executable to format the test result log. In doing so, it also merges the `OutputError` with the `ProcessError` to simplify the error formatting.