### PR TITLE
Pass Test Cases to a Test Executable Using Standard Input and Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "commander": "^13.1.0"
+    "commander": "^13.1.0",
+    "valibot": "^1.0.0",
+    "yaml": "^2.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      valibot:
+        specifier: ^1.0.0
+        version: 1.1.0(typescript@5.8.3)
+      yaml:
+        specifier: ^2.7.1
+        version: 2.8.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.26.0
@@ -23,7 +29,7 @@ importers:
         version: 22.15.18
       '@vitest/coverage-v8':
         specifier: ^3.0.7
-        version: 3.0.7(vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3))
+        version: 3.0.7(vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0))
       eslint:
         specifier: ^9.26.0
         version: 9.26.0
@@ -41,10 +47,10 @@ importers:
         version: 8.32.1(eslint@9.26.0)(typescript@5.8.3)
       vite-node:
         specifier: ^3.1.3
-        version: 3.1.3(@types/node@22.15.18)(tsx@4.19.3)
+        version: 3.1.3(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
       vitest:
         specifier: ^3.0.7
-        version: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)
+        version: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
 
 packages:
 
@@ -1701,6 +1707,14 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  valibot@1.1.0:
+    resolution: {integrity: sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -1847,6 +1861,11 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2353,7 +2372,7 @@ snapshots:
       '@typescript-eslint/types': 8.32.1
       eslint-visitor-keys: 4.2.0
 
-  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3))':
+  '@vitest/coverage-v8@3.0.7(vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2367,7 +2386,7 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)
+      vitest: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2378,13 +2397,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3))':
+  '@vitest/mocker@3.0.7(vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.1.0(@types/node@22.15.18)(tsx@4.19.3)
+      vite: 6.1.0(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.0.7':
     dependencies:
@@ -3411,15 +3430,19 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  valibot@1.1.0(typescript@5.8.3):
+    optionalDependencies:
+      typescript: 5.8.3
+
   vary@1.1.2: {}
 
-  vite-node@3.0.7(@types/node@22.15.18)(tsx@4.19.3):
+  vite-node@3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.18)(tsx@4.19.3)
+      vite: 6.3.5(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3434,13 +3457,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.1.3(@types/node@22.15.18)(tsx@4.19.3):
+  vite-node@3.1.3(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.5(@types/node@22.15.18)(tsx@4.19.3)
+      vite: 6.3.5(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -3455,7 +3478,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3):
+  vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
@@ -3464,8 +3487,9 @@ snapshots:
       '@types/node': 22.15.18
       fsevents: 2.3.3
       tsx: 4.19.3
+      yaml: 2.8.0
 
-  vite@6.3.5(@types/node@22.15.18)(tsx@4.19.3):
+  vite@6.3.5(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.4
       fdir: 6.4.4(picomatch@4.0.2)
@@ -3477,11 +3501,12 @@ snapshots:
       '@types/node': 22.15.18
       fsevents: 2.3.3
       tsx: 4.19.3
+      yaml: 2.8.0
 
-  vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3):
+  vitest@3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3))
+      '@vitest/mocker': 3.0.7(vite@6.1.0(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.0.7
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -3497,8 +3522,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.1.0(@types/node@22.15.18)(tsx@4.19.3)
-      vite-node: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)
+      vite: 6.1.0(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
+      vite-node: 3.0.7(@types/node@22.15.18)(tsx@4.19.3)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.18
@@ -3540,6 +3565,8 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, test } from "vitest";
-import { CompileError, ProcessError, RunError } from "./errors.js";
+
+import {
+  AssertionError,
+  CompileError,
+  ProcessError,
+  ReadError,
+  RunError,
+  TestError,
+} from "./errors.js";
+
+test("create an assertion error", { concurrent: true }, () => {
+  const err = new AssertionError("name", "actual", "expected");
+  expect(err.name).toBe("AssertionError");
+  expect(err.message).toBe(
+    "Failed to assert: name\nActual: actual\nExpected: expected",
+  );
+});
 
 test("create a compile error", { concurrent: true }, () => {
   const err = new CompileError([new Error()], "main.cpp");
@@ -22,9 +38,23 @@ describe("create process errors", { concurrent: true }, () => {
   });
 });
 
+test("create a read error", { concurrent: true }, () => {
+  const err = new ReadError([new Error()], "file.txt");
+  expect(err.name).toBe("ReadError");
+  expect(err.message).toBe("Failed to read: file.txt");
+  expect(err.errors).toStrictEqual([new Error()]);
+});
+
 test("create a run error", { concurrent: true }, () => {
   const err = new RunError([new Error()], "main");
   expect(err.name).toBe("RunError");
   expect(err.message).toBe("Failed to run: main");
+  expect(err.errors).toStrictEqual([new Error()]);
+});
+
+test("create a test error", { concurrent: true }, () => {
+  const err = new TestError([new Error()], "main");
+  expect(err.name).toBe("TestError");
+  expect(err.message).toBe("Failed to test: main");
   expect(err.errors).toStrictEqual([new Error()]);
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,3 +1,14 @@
+export class AssertionError extends Error {
+  constructor(name: string, actual: string, expected: string) {
+    super(
+      `Failed to assert: ${name}\nActual: ${actual}\nExpected: ${expected}`,
+    );
+
+    this.name = this.constructor.name;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
 export class CompileError extends AggregateError {
   constructor(error: unknown[], file: string) {
     super(error, `Failed to compile: ${file}`);
@@ -23,9 +34,27 @@ export class ProcessError extends Error {
   }
 }
 
+export class ReadError extends AggregateError {
+  constructor(error: unknown[], file: string) {
+    super(error, `Failed to read: ${file}`);
+
+    this.name = this.constructor.name;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
 export class RunError extends AggregateError {
   constructor(error: unknown[], file: string) {
     super(error, `Failed to run: ${file}`);
+
+    this.name = this.constructor.name;
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}
+
+export class TestError extends AggregateError {
+  constructor(error: unknown[], file: string) {
+    super(error, `Failed to test: ${file}`);
 
     this.name = this.constructor.name;
     Error.captureStackTrace?.(this, this.constructor);

--- a/src/internal/cases.test.ts
+++ b/src/internal/cases.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, expect, test } from "vitest";
+import { createTempFs, removeAllTempFs } from "./../../test/temp-fs.js";
+import { readTestCasesFile } from "./cases.js";
+
+test("read test cases file", async () => {
+  const tempDir = await createTempFs({
+    "cases.yaml": [
+      "example_1:",
+      "  inputs:",
+      "    str1: foo",
+      "    str2: bar",
+      "  output: foobar",
+      "",
+      "example_2:",
+      "  inputs:",
+      "    str1: foo",
+      "    str2: baz",
+      "  output: foobaz",
+    ],
+  });
+
+  const testCases = await readTestCasesFile(tempDir["cases.yaml"].$path);
+  expect(testCases).toStrictEqual([
+    {
+      name: "example_1",
+      inputs: [
+        { name: "str1", value: "foo" },
+        { name: "str2", value: "bar" },
+      ],
+      output: "foobar",
+    },
+    {
+      name: "example_2",
+      inputs: [
+        { name: "str1", value: "foo" },
+        { name: "str2", value: "baz" },
+      ],
+      output: "foobaz",
+    },
+  ]);
+});
+
+afterAll(() => removeAllTempFs());

--- a/src/internal/cases.ts
+++ b/src/internal/cases.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import * as v from "valibot";
+import yaml from "yaml";
+
+const testCasesFileSchema = v.record(
+  v.string(),
+  v.object({
+    inputs: v.record(v.string(), v.string()),
+    output: v.string(),
+  }),
+);
+
+export interface TestCase {
+  name: string;
+  inputs: { name: string; value: string }[];
+  output: string;
+}
+
+export async function readTestCasesFile(path: string): Promise<TestCase[]> {
+  const content = await readFile(path, "utf-8");
+  const parsedContent = v.parse(testCasesFileSchema, yaml.parse(content));
+  return Object.entries(parsedContent).map(([name, { inputs, output }]) => ({
+    name,
+    inputs: Object.entries(inputs).map(([name, value]) => ({ name, value })),
+    output,
+  }));
+}

--- a/src/internal/solution.test.ts
+++ b/src/internal/solution.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "vitest";
-import { CompileError, RunError } from "../errors.js";
+import { CompileError, ReadError, RunError, TestError } from "../errors.js";
 import { testCppSolution } from "./solution.js";
 import { createTempFs, removeAllTempFs } from "../../test/temp-fs.js";
 
@@ -7,9 +7,37 @@ describe(
   "test C++ solutions",
   { concurrent: true, timeout: 30000 },
   async () => {
+    const casesYaml: string[] = [
+      "example_1:",
+      "  inputs:",
+      "    str1: foo",
+      "    str2: bar",
+      "  output: foobar",
+      "",
+      "example_2:",
+      "  inputs:",
+      "    str1: foo",
+      "    str2: baz",
+      "  output: foobaz",
+    ];
+
     test("success", async () => {
       const root = await createTempFs({
-        "test.cpp": "int main() { return 0; }",
+        "test.cpp": [
+          "#include <iostream>",
+          "",
+          "int main() {",
+          "  int n{};",
+          "  std::cin >> n;",
+          "  while (--n >= 0) {",
+          "    std::string s1{}, s2{};",
+          "    std::cin >> s1 >> s2;",
+          "    std::cout << s1 + s2 << std::endl;",
+          "  }",
+          "  return 0;",
+          "}",
+        ],
+        "cases.yaml": casesYaml,
       });
 
       await testCppSolution(root.$path);
@@ -24,13 +52,46 @@ describe(
       await expect(prom).rejects.toThrow(CompileError);
     });
 
-    test("run error", async () => {
+    test("read error", async () => {
       const root = await createTempFs({
         "test.cpp": "int main() { return 1; }",
       });
 
       const prom = testCppSolution(root.$path);
+      await expect(prom).rejects.toThrow(ReadError);
+    });
+
+    test("run error", async () => {
+      const root = await createTempFs({
+        "test.cpp": "int main() { return 1; }",
+        "cases.yaml": casesYaml,
+      });
+
+      const prom = testCppSolution(root.$path);
       await expect(prom).rejects.toThrow(RunError);
+    });
+
+    test("test error", async () => {
+      const root = await createTempFs({
+        "test.cpp": [
+          "#include <iostream>",
+          "",
+          "int main() {",
+          "  int n{};",
+          "  std::cin >> n;",
+          "  while (--n >= 0) {",
+          "    std::string s1{}, s2{};",
+          "    std::cin >> s1 >> s2;",
+          "    std::cout << s1 << std::endl;",
+          "  }",
+          "  return 0;",
+          "}",
+        ],
+        "cases.yaml": casesYaml,
+      });
+
+      const prom = testCppSolution(root.$path);
+      await expect(prom).rejects.toThrow(TestError);
     });
   },
 );

--- a/src/internal/utils/process.ts
+++ b/src/internal/utils/process.ts
@@ -10,6 +10,10 @@ export async function waitProcess(
     proc.stderr.on("data", (chunk) => chunks.push(chunk));
 
     proc.on("error", reject);
+    proc.stdin.on("error", reject);
+    proc.stdout.on("error", reject);
+    proc.stderr.on("error", reject);
+
     proc.on("close", (code) => {
       if (code === 0) {
         resolve();

--- a/src/internal/utils/queue.test.ts
+++ b/src/internal/utils/queue.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+import { Queue } from "./queue.js";
+
+test("queue items", () => {
+  const queue = new Queue<number>();
+
+  expect(queue.peek()).toBe(undefined);
+  expect(queue.pop()).toBe(undefined);
+
+  queue.push(1);
+  queue.push(2);
+  queue.push(3);
+
+  expect(queue.peek()).toBe(1);
+  expect(queue.pop()).toBe(1);
+  expect(queue.peek()).toBe(2);
+  expect(queue.pop()).toBe(2);
+
+  queue.push(4);
+
+  expect(queue.peek()).toBe(3);
+  expect(queue.pop()).toBe(3);
+  expect(queue.peek()).toBe(4);
+  expect(queue.pop()).toBe(4);
+
+  expect(queue.peek()).toBe(undefined);
+  expect(queue.pop()).toBe(undefined);
+});

--- a/src/internal/utils/queue.ts
+++ b/src/internal/utils/queue.ts
@@ -1,0 +1,33 @@
+export class Queue<T> {
+  #items: T[];
+  #offset: number;
+
+  constructor() {
+    this.#items = [];
+    this.#offset = 0;
+  }
+
+  push(item: T) {
+    this.#items.push(item);
+  }
+
+  peek(): T | undefined {
+    return this.#offset < this.#items.length
+      ? this.#items[this.#offset]
+      : undefined;
+  }
+
+  pop(): T | undefined {
+    const item = this.peek();
+    if (item !== undefined) {
+      ++this.#offset;
+
+      // Clean up to prevent memory leak.
+      if (this.#offset * 2 >= this.#items.length) {
+        this.#items = this.#items.slice(this.#offset);
+        this.#offset = 0;
+      }
+    }
+    return item;
+  }
+}

--- a/src/internal/utils/stream.test.ts
+++ b/src/internal/utils/stream.test.ts
@@ -1,0 +1,31 @@
+import { Readable } from "node:stream";
+import { expect, test } from "vitest";
+import { StreamReader } from "./stream.js";
+
+test("read line streams", async () => {
+  const stream = new Readable({
+    read: () => {
+      // Do nothing.
+    },
+  });
+
+  const reader = new StreamReader(stream);
+
+  let prom = reader.readLine();
+  stream.push("foo\nbar\nbaz");
+
+  await expect(prom).resolves.toBe("foo");
+  await expect(reader.readLine()).resolves.toBe("bar");
+
+  prom = reader.readLine();
+  stream.push("baz");
+  setTimeout(() => stream.push("baz\nbaz"), 1000);
+
+  await expect(prom).resolves.toBe("bazbazbaz");
+
+  prom = reader.readLine();
+  stream.destroy();
+
+  await expect(prom).rejects.toThrow("Stream closed");
+  await expect(reader.readLine()).rejects.toThrow("Stream closed");
+});

--- a/src/internal/utils/stream.ts
+++ b/src/internal/utils/stream.ts
@@ -1,0 +1,63 @@
+import type { Readable } from "node:stream";
+import { Queue } from "./queue.js";
+
+interface ReadResolver {
+  resolve: (value: string) => void;
+  reject: (reason?: unknown) => void;
+}
+
+export class StreamReader {
+  #stream: Readable;
+  #buffer: string;
+  #readResolverQueue: Queue<ReadResolver>;
+
+  constructor(stream: Readable) {
+    this.#stream = stream;
+    this.#buffer = "";
+    this.#readResolverQueue = new Queue();
+
+    this.#stream.setEncoding("utf-8");
+
+    this.#stream.on("data", (chunk: string) => {
+      this.#buffer += chunk;
+
+      let prevIdx = 0;
+      let resolver: ReadResolver | undefined;
+      while ((resolver = this.#readResolverQueue.peek()) !== undefined) {
+        const idx = this.#buffer.indexOf("\n", prevIdx);
+        if (idx === -1) break;
+
+        resolver.resolve(this.#buffer.slice(prevIdx, idx));
+        this.#readResolverQueue.pop();
+        prevIdx = idx + 1;
+      }
+
+      this.#buffer = this.#buffer.slice(prevIdx);
+    });
+
+    this.#stream.on("close", () => {
+      let resolver: ReadResolver | undefined;
+      while ((resolver = this.#readResolverQueue.peek()) !== undefined) {
+        resolver.reject(new Error("Stream closed"));
+        this.#readResolverQueue.pop();
+      }
+    });
+  }
+
+  async readLine(): Promise<string> {
+    if (this.#stream.closed) {
+      throw new Error("Stream closed");
+    }
+
+    const idx = this.#buffer.indexOf("\n");
+    if (idx !== -1) {
+      const line = this.#buffer.slice(0, idx);
+      this.#buffer = this.#buffer.slice(idx + 1);
+      return line;
+    }
+
+    return new Promise<string>((resolve, reject) =>
+      this.#readResolverQueue.push({ resolve, reject }),
+    );
+  }
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,2 +1,10 @@
-export { CompileError, ProcessError, RunError } from "./errors.js";
+export {
+  AssertionError,
+  CompileError,
+  ProcessError,
+  ReadError,
+  RunError,
+  TestError,
+} from "./errors.js";
+
 export { type TestResult, testSolutions } from "./solution.js";


### PR DESCRIPTION
This pull request resolves #487 by modifying the `testCppSolution` function to pass test cases to a test executable using the executable's standard I/O. In doing so, it also introduces the following changes:

* Added a step to read test cases from a `cases.yaml` file.
* Added new `Queue<T>` and `StreamReader` utility classes.
* Modified the `waitProcess` function to handle errors on standard I/O.