### PR TITLE
Add Support for Testing on macOS in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,11 @@ jobs:
 
   test-library:
     name: Test Library
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-14]
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 on:
   workflow_dispatch:
   pull_request:
@@ -27,8 +27,21 @@ jobs:
       - name: Check Types
         run: pnpm tsc --noEmit
 
-      - name: Test Library
-        run: pnpm test
-
       - name: Package Library
         run: pnpm pack
+
+  test-library:
+    name: Test Library
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.2.2
+
+      - name: Setup pnpm
+        uses: threeal/setup-pnpm-action@v1.0.0
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Test Library
+        run: pnpm test


### PR DESCRIPTION
This pull request resolves #667 by adding support in CI for testing on macOS. In doing so, it also separates the `test-library` job from the `build-library` job and renames the workflow to `ci.yaml`.