### PR TITLE
feat: remove properties in errors

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,21 +1,13 @@
 export class CompileError extends AggregateError {
-  file: string;
-
   constructor(error: unknown[], file: string) {
     super(error, `Failed to compile: ${file}`);
 
     this.name = this.constructor.name;
-    this.file = file;
-
     Error.captureStackTrace?.(this, this.constructor);
   }
 }
 
 export class ProcessError extends Error {
-  args: readonly string[];
-  code: number | null;
-  output: string;
-
   constructor(args: readonly string[], code: number | null, output: string) {
     let message = "Process failed";
     if (code !== null) message += ` (${code})`;
@@ -27,23 +19,15 @@ export class ProcessError extends Error {
     super(message);
 
     this.name = this.constructor.name;
-    this.args = args;
-    this.code = code;
-    this.output = output;
-
     Error.captureStackTrace?.(this, this.constructor);
   }
 }
 
 export class RunError extends AggregateError {
-  file: string;
-
   constructor(error: unknown[], file: string) {
     super(error, `Failed to run: ${file}`);
 
     this.name = this.constructor.name;
-    this.file = file;
-
     Error.captureStackTrace?.(this, this.constructor);
   }
 }


### PR DESCRIPTION
This pull request resolves #686 by removing properties in `CompileError`, `ProcessError`, and `RunError` classes.