### PR TITLE
Add Utility Function to Remove All Temporary File Systems

### DIFF
--- a/src/internal/utils/temp-fs.ts
+++ b/src/internal/utils/temp-fs.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -6,9 +6,12 @@ export interface FsTree {
   [key: string]: FsTree | string | string[];
 }
 
+let tempDirs: string[] = [];
+
 export async function createTempFs(tree: FsTree): Promise<string> {
   const dir = await mkdtemp(path.join(os.tmpdir(), "temp"));
   await createTempFsRecursively(dir, tree);
+  tempDirs.push(dir);
   return dir;
 }
 
@@ -27,4 +30,11 @@ async function createTempFsRecursively(dir: string, tree: FsTree) {
       }
     }),
   );
+}
+
+export async function removeAllTempFs(): Promise<void> {
+  await Promise.all(
+    tempDirs.map((tempDir) => rm(tempDir, { recursive: true })),
+  );
+  tempDirs = [];
 }

--- a/src/solution.test.ts
+++ b/src/solution.test.ts
@@ -1,8 +1,8 @@
-import { readFile, rm } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { afterAll, expect, test, vi } from "vitest";
 import { testCppSolution } from "./internal/solution.js";
-import { createTempFs } from "./internal/utils/temp-fs.js";
+import { createTempFs, removeAllTempFs } from "./internal/utils/temp-fs.js";
 import { type TestResult, testSolutions } from "./solution.js";
 
 vi.mock("./internal/solution.js", () => ({
@@ -14,23 +14,23 @@ vi.mocked(testCppSolution).mockImplementation(async (dir) => {
   if (content !== "valid\n") throw new Error();
 });
 
-const tempDir = await createTempFs({
-  foo: {
+test("test solutions", async () => {
+  const tempDir = await createTempFs({
+    foo: {
+      bar: {
+        "test.cpp": "valid",
+      },
+      baz: {
+        "test.js": "valid",
+      },
+      "test.cpp": "invalid",
+    },
     bar: {
       "test.cpp": "valid",
     },
-    baz: {
-      "test.js": "valid",
-    },
-    "test.cpp": "invalid",
-  },
-  bar: {
-    "test.cpp": "valid",
-  },
-  baz: {},
-});
+    baz: {},
+  });
 
-test("test solutions", async () => {
   const results: TestResult[] = [];
   for await (const result of testSolutions(tempDir)) {
     results.push(result);
@@ -43,4 +43,4 @@ test("test solutions", async () => {
   ]);
 });
 
-afterAll(() => rm(tempDir, { recursive: true }));
+afterAll(() => removeAllTempFs());


### PR DESCRIPTION
This pull request resolves #688 by adding a new `removeAllTempFs` utility function, simplifying tests.