### PR TITLE
Modify `createTempFs` Utility to Return Tree of Paths

### DIFF
--- a/src/internal/solution.test.ts
+++ b/src/internal/solution.test.ts
@@ -8,28 +8,28 @@ describe(
   { concurrent: true, timeout: 30000 },
   async () => {
     test("success", async () => {
-      const tempDir = await createTempFs({
+      const root = await createTempFs({
         "test.cpp": "int main() { return 0; }",
       });
 
-      await testCppSolution(tempDir);
+      await testCppSolution(root.$path);
     });
 
     test("compile error", async () => {
-      const tempDir = await createTempFs({
+      const root = await createTempFs({
         "test.cpp": "int main() {",
       });
 
-      const prom = testCppSolution(tempDir);
+      const prom = testCppSolution(root.$path);
       await expect(prom).rejects.toThrow(CompileError);
     });
 
     test("run error", async () => {
-      const tempDir = await createTempFs({
+      const root = await createTempFs({
         "test.cpp": "int main() { return 1; }",
       });
 
-      const prom = testCppSolution(tempDir);
+      const prom = testCppSolution(root.$path);
       await expect(prom).rejects.toThrow(RunError);
     });
   },

--- a/src/internal/utils/temp-fs.ts
+++ b/src/internal/utils/temp-fs.ts
@@ -2,34 +2,50 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
-export interface FsTree {
-  [key: string]: FsTree | string | string[];
+export interface FsContentTree {
+  [key: string]: FsContentTree | string | string[];
 }
+
+export type FsTree<T> = { $path: string } & {
+  [K in keyof T]: T[K] extends string | string[]
+    ? { $path: string }
+    : FsTree<T[K]>;
+};
 
 let tempDirs: string[] = [];
 
-export async function createTempFs(tree: FsTree): Promise<string> {
-  const dir = await mkdtemp(path.join(os.tmpdir(), "temp"));
-  await createTempFsRecursively(dir, tree);
-  tempDirs.push(dir);
-  return dir;
+export async function createTempFs<T extends FsContentTree>(
+  contentTree: T,
+): Promise<FsTree<T>> {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "temp"));
+  tempDirs.push(tempDir);
+
+  return createTempFsRecursively(tempDir, contentTree);
 }
 
-async function createTempFsRecursively(dir: string, tree: FsTree) {
-  await Promise.all(
-    Object.entries(tree).map(async ([key, val]) => {
-      if (typeof val === "object") {
-        if (Array.isArray(val)) {
-          return writeFile(path.join(dir, key), `${val.join("\n")}\n`);
+async function createTempFsRecursively<T extends FsContentTree>(
+  parentDir: string,
+  contentTree: T,
+): Promise<FsTree<T>> {
+  const entries = await Promise.all(
+    Object.entries(contentTree).map(async ([name, content]) => {
+      const $path = path.join(parentDir, name);
+      if (typeof content === "object") {
+        if (Array.isArray(content)) {
+          await writeFile($path, `${content.join("\n")}\n`);
+          return [name, { $path }];
         } else {
-          await mkdir(path.join(dir, key));
-          return createTempFsRecursively(path.join(dir, key), val);
+          await mkdir($path);
+          return [name, await createTempFsRecursively($path, content)];
         }
       } else {
-        return writeFile(path.join(dir, key), `${val}\n`);
+        await writeFile($path, `${content}\n`);
+        return [name, { $path }];
       }
     }),
   );
+  entries.push(["$path", parentDir]);
+  return Object.fromEntries(entries);
 }
 
 export async function removeAllTempFs(): Promise<void> {

--- a/src/solution.test.ts
+++ b/src/solution.test.ts
@@ -15,31 +15,25 @@ vi.mocked(testCppSolution).mockImplementation(async (dir) => {
 });
 
 test("test solutions", async () => {
-  const tempDir = await createTempFs({
+  const root = await createTempFs({
     foo: {
-      bar: {
-        "test.cpp": "valid",
-      },
-      baz: {
-        "test.js": "valid",
-      },
+      bar: { "test.cpp": "valid" },
+      baz: { "test.js": "valid" },
       "test.cpp": "invalid",
     },
-    bar: {
-      "test.cpp": "valid",
-    },
+    bar: { "test.cpp": "valid" },
     baz: {},
   });
 
   const results: TestResult[] = [];
-  for await (const result of testSolutions(tempDir)) {
+  for await (const result of testSolutions(root.$path)) {
     results.push(result);
   }
 
   expect(results).toEqual([
-    { dir: path.join(tempDir, "bar"), err: undefined },
-    { dir: path.join(tempDir, "foo"), err: new Error() },
-    { dir: path.join(tempDir, "foo", "bar"), err: undefined },
+    { dir: root.bar.$path, err: undefined },
+    { dir: root.foo.$path, err: new Error() },
+    { dir: root.foo.bar.$path, err: undefined },
   ]);
 });
 


### PR DESCRIPTION
This pull request resolves #691 by modifying the `createTempFs` utility function to return a tree of paths as the `FsTree` type. This change also renames the previous `FsTree` type to `FsContentTree`, specifically for trees that contain the content of the filesystem.