### PR TITLE
Test All Files

### DIFF
--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from "vitest";
-import * as solutionModule from "./solution.js";
+import * as solutionModule from "./lib.js";
 
 interface Output {
   type: "stdout" | "stderr";

--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -1,0 +1,40 @@
+import { expect, test, vi } from "vitest";
+import * as solutionModule from "./solution.js";
+
+interface Output {
+  type: "stdout" | "stderr";
+  buffer: string | Uint8Array;
+}
+
+test("run executable", async () => {
+  const output: Output[] = [];
+
+  vi.spyOn(process.stdout, "write").mockImplementation((buffer) => {
+    output.push({ type: "stdout", buffer });
+    return true;
+  });
+
+  vi.spyOn(process.stderr, "write").mockImplementation((buffer) => {
+    output.push({ type: "stderr", buffer });
+    return true;
+  });
+
+  vi.spyOn(solutionModule, "testSolutions").mockImplementation(
+    async function* () {
+      yield { dir: "foo", err: undefined };
+      yield { dir: "bar", err: new Error("something happened") };
+    },
+  );
+
+  process.argv = ["node", "bin.js"];
+  await import("./bin.js");
+
+  expect(output).toStrictEqual([
+    { type: "stdout", buffer: "\x1b[32m✔\x1b[0m Tested foo\n" },
+    {
+      type: "stderr",
+      buffer:
+        "\x1b[31m✖\x1b[0m Failed to test bar\n\x1b[30m  something happened\x1b[0m\n",
+    },
+  ]);
+});

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
 import { program } from "commander";
-import { testSolutions } from "./solution.js";
 import { stringifyError } from "./internal/utils/stringify.js";
+import { testSolutions } from "./lib.js";
 
 program
   .name("leettest")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     coverage: {
-      all: false,
       enabled: true,
       reporter: ["text"],
       thresholds: { 100: true },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     coverage: {
       enabled: true,
-      reporter: ["text"],
+      reporter: "text",
       thresholds: { 100: true },
     },
   },


### PR DESCRIPTION
This pull request resolves #733 mainly by removing the `test.coverage.all` configuration in `vitest.config.ts`, which by default makes Vitest check test coverage on all files. To satisfy the coverage requirements, this change also adds a test for the `src/bin.ts` file.

Additionally, this pull request modifies other parts of the codebase, with details available in the individual commits.