### PR TITLE
Extend TypeScript Build Configuration from External Config

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,10 +1,9 @@
 {
-  "extends": "./tsconfig",
+  "extends": "@tsconfig/node24",
   "include": ["src"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "declaration": true,
-    "noEmit": false,
     "outDir": "dist"
   }
 }


### PR DESCRIPTION
This pull request resolves #739 by modifying the `tsconfig.build.json` file to be extended from `@tsconfig/node24`.