### PR TITLE
Fix Async Function Lint Issue

### DIFF
--- a/src/bin.test.ts
+++ b/src/bin.test.ts
@@ -20,6 +20,7 @@ test("run executable", async () => {
   });
 
   vi.spyOn(solutionModule, "testSolutions").mockImplementation(
+    // eslint-disable-next-line @typescript-eslint/require-await
     async function* () {
       yield { dir: "foo", err: undefined };
       yield { dir: "bar", err: new Error("something happened") };


### PR DESCRIPTION
This pull request resolves #749 by ignoring `@typescript-eslint/require-await` on mocked functions.