### PR TITLE
Add Prettier Plugin for Organizing Imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .*
 !.git*
 !.npmrc
-!.prettierignore
+!.prettier*
 
 build/
 dist/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-organize-imports"]
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "jiti": "^2.5.1",
     "lefthook": "^1.12.2",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.2.0",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "vitest": "^3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-organize-imports:
+        specifier: ^4.2.0
+        version: 4.2.0(prettier@3.6.2)(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -1217,6 +1220,16 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-organize-imports@4.2.0:
+    resolution: {integrity: sha512-Zdy27UhlmyvATZi67BTnLcKTo8fm6Oik59Sz6H64PgZJVs6NJpPD1mT240mmJn62c98/QaL+r3kx9Q3gRpDajg==}
+    peerDependencies:
+      prettier: '>=2.0'
+      typescript: '>=2.9'
+      vue-tsc: ^2.1.0 || 3
+    peerDependenciesMeta:
+      vue-tsc:
+        optional: true
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -2514,6 +2527,11 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-organize-imports@4.2.0(prettier@3.6.2)(typescript@5.8.3):
+    dependencies:
+      prettier: 3.6.2
+      typescript: 5.8.3
 
   prettier@3.6.2: {}
 

--- a/src/internal/solution.test.ts
+++ b/src/internal/solution.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, describe, expect, test } from "vitest";
+import { createTempFs, removeAllTempFs } from "../../test/temp-fs.js";
 import { CompileError, ReadError, RunError, TestError } from "../errors.js";
 import { testCppSolution } from "./solution.js";
-import { createTempFs, removeAllTempFs } from "../../test/temp-fs.js";
 
 describe("test C++ solutions", { concurrent: true, timeout: 30000 }, () => {
   const casesYaml: string[] = [

--- a/src/internal/solution.ts
+++ b/src/internal/solution.ts
@@ -10,9 +10,9 @@ import {
   TestError,
 } from "../errors.js";
 
+import { readTestCasesFile } from "./cases.js";
 import { waitProcess } from "./utils/process.js";
 import { StreamReader } from "./utils/stream.js";
-import { readTestCasesFile } from "./cases.js";
 
 export async function testCppSolution(dir: string): Promise<void> {
   const testCppFile = path.join(dir, "test.cpp");

--- a/src/internal/utils/process.test.ts
+++ b/src/internal/utils/process.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process";
 import { describe, expect, test } from "vitest";
-import { waitProcess } from "./process.js";
 import { ProcessError } from "../../errors.js";
+import { waitProcess } from "./process.js";
 
 describe("wait child processes", { concurrent: true }, () => {
   test("node --version", async () => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -7,4 +7,4 @@ export {
   TestError,
 } from "./errors.js";
 
-export { type TestResult, testSolutions } from "./solution.js";
+export { testSolutions, type TestResult } from "./solution.js";

--- a/src/solution.test.ts
+++ b/src/solution.test.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { afterAll, expect, test, vi } from "vitest";
-import { testCppSolution } from "./internal/solution.js";
 import { createTempFs, removeAllTempFs } from "../test/temp-fs.js";
+import { testCppSolution } from "./internal/solution.js";
 import { type TestResult, testSolutions } from "./solution.js";
 
 vi.mock("./internal/solution.js", () => ({


### PR DESCRIPTION
This pull request resolves #786 by adding [prettier-plugin-organize-imports](https://www.npmjs.com/package/prettier-plugin-organize-imports) to this project. This change also fixes formatting by organizing imports according to the plugin's rules.