### PR TITLE
Make `.gitignore` rules for dot-prefixed files more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
 .*
-!.git*
+!.github/
+!.gitattributes
+!.gitignore
 !.npmrc
-!.prettier*
+!.prettierignore
+!.prettierrc.json
 
 build/
 dist/
 node_modules/
-
 *.tgz


### PR DESCRIPTION
This pull request resolves #960 by making the rules for including dot-prefixed files in `.gitignore` more specific.