### PR TITLE
Update CI to validate pre-commit hooks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,25 +12,19 @@ jobs:
       - name: Checkout Project
         uses: actions/checkout@v6.0.2
 
+      - name: Setup Lefthook
+        uses: threeal/setup-lefthook-action@v1.0.0
+
       - name: Setup pnpm
         uses: threeal/setup-pnpm-action@v1.0.0
         with:
           version: 10.33.4
 
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Check Types
-        run: pnpm tsc
+      - name: Check pre-commit hook
+        run: lefthook run pre-commit --all-files
 
       - name: Test Library
         run: pnpm test
-
-      - name: Check Formatting
-        run: pnpm prettier --check .
-
-      - name: Check Lint
-        run: pnpm eslint
 
       - name: Package Library
         run: pnpm pack


### PR DESCRIPTION
This pull request resolves #968 by:
- Replaces individual CI check steps (type checking, formatting, linting, documentation) with a single `lefthook run pre-commit --all-files` step
- Adds a Lefthook installation step via [Setup Lefthook action](https://github.com/marketplace/actions/setup-lefthook)
- Ensures pre-commit hooks themselves are validated in CI before merging
