### PR TITLE
Rename build workflow to CI and simplify workflow names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,15 +1,15 @@
-name: Build
+name: CI
 on:
   workflow_dispatch:
   pull_request:
   push:
     branches: [main]
 jobs:
-  build-library:
-    name: Build Library
+  build:
+    name: Build
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout Project
+      - name: Checkout
         uses: actions/checkout@v6.0.3
 
       - name: Setup Lefthook
@@ -23,8 +23,8 @@ jobs:
       - name: Check pre-commit hook
         run: lefthook run pre-commit --all-files
 
-      - name: Test Library
+      - name: Test
         run: pnpm test
 
-      - name: Package Library
+      - name: Package
         run: pnpm pack


### PR DESCRIPTION
This pull request resolves #970 by:
- Rename `.github/workflows/build.yaml` to `ci.yaml` with workflow name `CI`
- Simplify job and step names in both workflows (e.g. `Checkout Project` → `Checkout`, `Test Library` → `Test`)